### PR TITLE
added disconnect reason

### DIFF
--- a/azalea-client/src/client.rs
+++ b/azalea-client/src/client.rs
@@ -422,6 +422,7 @@ impl Client {
     pub fn disconnect(&self) {
         self.ecs.lock().send_event(DisconnectEvent {
             entity: self.entity,
+            reason: None,
         });
     }
 

--- a/azalea-client/src/disconnect.rs
+++ b/azalea-client/src/disconnect.rs
@@ -33,6 +33,7 @@ impl Plugin for DisconnectPlugin {
 #[derive(Event)]
 pub struct DisconnectEvent {
     pub entity: Entity,
+    pub reason: Option<String>,
 }
 
 /// System that removes the [`JoinedClientBundle`] from the entity when it
@@ -41,7 +42,7 @@ pub fn remove_components_from_disconnected_players(
     mut commands: Commands,
     mut events: EventReader<DisconnectEvent>,
 ) {
-    for DisconnectEvent { entity } in events.read() {
+    for DisconnectEvent { entity, .. } in events.read() {
         commands.entity(*entity).remove::<JoinedClientBundle>();
     }
 }
@@ -64,7 +65,7 @@ fn disconnect_on_connection_dead(
 ) {
     for (entity, &is_connection_alive) in &query {
         if !*is_connection_alive {
-            disconnect_events.send(DisconnectEvent { entity });
+            disconnect_events.send(DisconnectEvent { entity, reason: None });
         }
     }
 }

--- a/azalea-client/src/packet_handling/configuration.rs
+++ b/azalea-client/src/packet_handling/configuration.rs
@@ -104,6 +104,7 @@ pub fn process_packet_events(ecs: &mut World) {
                 let mut disconnect_events = system_state.get_mut(ecs);
                 disconnect_events.send(DisconnectEvent {
                     entity: player_entity,
+                    reason: Some(p.reason.to_ansi()),
                 });
             }
             ClientboundConfigurationPacket::FinishConfiguration(p) => {

--- a/azalea-client/src/packet_handling/game.rs
+++ b/azalea-client/src/packet_handling/game.rs
@@ -401,6 +401,7 @@ pub fn process_packet_events(ecs: &mut World) {
                 let mut disconnect_events = system_state.get_mut(ecs);
                 disconnect_events.send(DisconnectEvent {
                     entity: player_entity,
+                    reason: Some(p.reason.to_ansi()),
                 });
             }
             ClientboundGamePacket::UpdateRecipes(_p) => {


### PR DESCRIPTION
Hello there,

with this PR I have added the possibility to catch disconnect events and their reason easily.

But here is an issue that I am facing and cannot figure out how to fix:
When the server disconnects us from the game, we normally get `ClientboundGamePacket::Disconnect` but the connection is closed before we can read the packet and fire the event with an reason. This causes us to not get the actual disconnect message and I really need HELP with this issue.

