### PR TITLE
Serde support for 'ServerAddress'

### DIFF
--- a/azalea-protocol/src/lib.rs
+++ b/azalea-protocol/src/lib.rs
@@ -76,6 +76,33 @@ impl Display for ServerAddress {
     }
 }
 
+///
+/// Serde Deserialization for ServerAddress
+/// This is necessary for config file usage
+/// We are not using TryFrom because we want to use the serde error system
+/// 
+impl<'de> serde::Deserialize<'de> for ServerAddress {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
+        let string = String::deserialize(deserializer)?;
+        let mut parts = string.split(':');
+        let host = parts.next().ok_or(serde::de::Error::custom("No host specified"))?.to_string();
+        // default the port to 25565
+        let port = parts.next().unwrap_or("25565");
+        let port = u16::from_str(port).map_err(|_| serde::de::Error::custom("Invalid port specified"))?;
+        Ok(ServerAddress { host, port })
+    }
+}
+
+///
+/// Serde Serialization for ServerAddress
+/// Pretty much like impl Display
+/// 
+impl serde::Serialize for ServerAddress {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+        serializer.serialize_str(&format!("{}:{}", self.host, self.port))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;


### PR DESCRIPTION
Hey there,

this PR adds support for serde serialization and deserialization for the ServerAdress struct. I find this quite useful for my configuration purposes and because this library already features serde, might add this support.