### PR TITLE
Replace Bevy's FixedUpdate with Azalea's GameTick

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,9 +534,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bevy_app"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172d532ea812e5954fa814dae003c207f2a0b20c6e50431787c94a7159677ece"
+checksum = "d41731817993f92e4363dd3335558e779e290bc71eefc0b5547052b85810907e"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24bf40259be12a1a24d9fd536f5ff18d31eeb5665b77e2732899783be6edc5d6"
+checksum = "f484318350462c58ba3942a45a656c1fd6b6e484a6b6b7abc3a787ad1a51e500"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -561,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae11a1f467c372b50e9d4b55e78370f5420c9db7416200cc441cc84f08174dd3"
+checksum = "7709fbd22f81fb681534cd913c41e1cd18b17143368743281195d7f024b61aea"
 dependencies = [
  "async-channel",
  "bevy_ecs_macros",
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f642c2b67c4d0daf8edf15074f6351457eb487a34b3de1290c760d8f3ac9ec16"
+checksum = "a8843aa489f159f25cdcd9fee75cd7d221a7098a71eaa72cb2d6b40ac4e3f1ba"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011417debf7868b45932bb97fc0d5bfdeaf9304e324aa94840e2f1e6deeed69d"
+checksum = "0dc10ba1d225a8477b9e80a1bf797d8a8b8274e83c9b24fb4d9351aec9229755"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6fba87c6d069fcbcd8a48625ca8ab4392ad40d2b260863ce7d641a0f42986d"
+checksum = "e566640c6b6dced73d2006c764c2cffebe1a82be4809486c4a5d7b4b50efed4d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -623,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752764558a1f429c20704c3b836a019fa308961c43fdfef4f08e339d456c96be"
+checksum = "58ddc2b76783939c530178f88e5711a1b01044d7b02db4033e2eb8b43b6cf4ec"
 dependencies = [
  "glam",
  "serde",
@@ -633,15 +633,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_ptr"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308a02679f6ce21ef71de20fae6d6a2016c07baa21d8e8d0558e6b7851e8adf2"
+checksum = "c77ec20c8fafcdc196508ef5ccb4f0400a8d193cb61f7b14a36ed9a25ad423cf"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd56914a8ad57621d7a1a099f7e6b1f7482c9c76cedc9c3d4c175a203939c5d"
+checksum = "d7921f15fc944c9c8ad01d7dbcea6505b8909c6655cd9382bab1407181556038"
 dependencies = [
  "bevy_math",
  "bevy_ptr",
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f627907c40ac552f798423447fc331fc1ddacd94c5f7a2a70942eb06bc8447"
+checksum = "b4a8c5475f216e751ef4452a1306b00711f33d2d04d9f149e4c845dfeb6753a0"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -671,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a45be906618192515bc613e46546150089adbb4a82178dc462045acd1e89e92"
+checksum = "f4fefa7fe0da8923525f7500e274f1bd60dbd79918a25cf7d0dfa0a6ba15c1cf"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29709cadf22d318a0b7c79f763e9c5ac414292bd0e850066fa935959021b276"
+checksum = "e6250d76eed3077128b6a3d004f9f198b01107800b9824051e32bb658054e837"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e75d4a34ef0b15dffd1ee9079ef1f0f5139527e192b9d5708b3e158777c753"
+checksum = "7915222f4a08ccc782e08d10b751b42e5f9d786e697d0cb3fd09333cb7e8b6ea"
 dependencies = [
  "ahash",
  "bevy_utils_proc_macros",
@@ -717,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils_proc_macros"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7dfd3735a61a1b681ed1e176afe4eae731bbb03e51ad871e9eb39e76a2d170e"
+checksum = "7aafecc952b6b8eb1a93c12590bd867d25df2f4ae1033a01dfdfc3c35ebccfff"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/azalea-client/Cargo.toml
+++ b/azalea-client/Cargo.toml
@@ -23,11 +23,11 @@ azalea-buf = { path = "../azalea-buf", version = "0.8.0" }
 azalea-protocol = { path = "../azalea-protocol", version = "0.8.0" }
 azalea-registry = { path = "../azalea-registry", version = "0.8.0" }
 azalea-world = { path = "../azalea-world", version = "0.8.0" }
-bevy_app = "0.12.0"
-bevy_ecs = "0.12.0"
-bevy_log = { version = "0.12.0", optional = true }
-bevy_tasks = "0.12.0"
-bevy_time = "0.12.0"
+bevy_app = "0.12.1"
+bevy_ecs = "0.12.1"
+bevy_log = { version = "0.12.1", optional = true }
+bevy_tasks = "0.12.1"
+bevy_time = "0.12.1"
 azalea-inventory = { path = "../azalea-inventory", version = "0.8.0" }
 derive_more = { version = "0.99.17", features = ["deref", "deref_mut"] }
 futures = "0.3.29"

--- a/azalea-client/src/attack.rs
+++ b/azalea-client/src/attack.rs
@@ -1,4 +1,4 @@
-use azalea_core::game_type::GameMode;
+use azalea_core::{game_type::GameMode, tick::GameTick};
 use azalea_entity::{
     metadata::{ShiftKeyDown, Sprinting},
     update_bounding_box, Attributes, Physics,
@@ -8,7 +8,7 @@ use azalea_protocol::packets::game::serverbound_interact_packet::{
     self, ServerboundInteractPacket,
 };
 use azalea_world::MinecraftEntityId;
-use bevy_app::{App, FixedUpdate, Plugin, Update};
+use bevy_app::{App, Plugin, Update};
 use bevy_ecs::prelude::*;
 use derive_more::{Deref, DerefMut};
 
@@ -29,7 +29,7 @@ impl Plugin for AttackPlugin {
                     .after(perform_respawn),
             )
             .add_systems(
-                FixedUpdate,
+                GameTick,
                 (
                     increment_ticks_since_last_attack,
                     update_attack_strength_scale.after(PhysicsSet),

--- a/azalea-client/src/events.rs
+++ b/azalea-client/src/events.rs
@@ -4,11 +4,12 @@
 use std::sync::Arc;
 
 use azalea_chat::FormattedText;
+use azalea_core::tick::GameTick;
 use azalea_protocol::packets::game::{
     clientbound_player_combat_kill_packet::ClientboundPlayerCombatKillPacket, ClientboundGamePacket,
 };
 use azalea_world::{InstanceName, MinecraftEntityId};
-use bevy_app::{App, FixedUpdate, Plugin, PreUpdate, Update};
+use bevy_app::{App, Plugin, PreUpdate, Update};
 use bevy_ecs::{
     component::Component,
     event::EventReader,
@@ -128,7 +129,7 @@ impl Plugin for EventPlugin {
             PreUpdate,
             init_listener.before(crate::packet_handling::game::process_packet_events),
         )
-        .add_systems(FixedUpdate, tick_listener);
+        .add_systems(GameTick, tick_listener);
     }
 }
 

--- a/azalea-client/src/mining.rs
+++ b/azalea-client/src/mining.rs
@@ -1,5 +1,5 @@
 use azalea_block::{Block, BlockState, FluidState};
-use azalea_core::{direction::Direction, game_type::GameMode, position::BlockPos};
+use azalea_core::{direction::Direction, game_type::GameMode, position::BlockPos, tick::GameTick};
 use azalea_entity::{mining::get_mine_progress, FluidOnEyes, Physics};
 use azalea_inventory::ItemSlot;
 use azalea_physics::PhysicsSet;
@@ -7,7 +7,7 @@ use azalea_protocol::packets::game::serverbound_player_action_packet::{
     self, ServerboundPlayerActionPacket,
 };
 use azalea_world::{InstanceContainer, InstanceName};
-use bevy_app::{App, FixedUpdate, Plugin, Update};
+use bevy_app::{App, Plugin, Update};
 use bevy_ecs::prelude::*;
 use derive_more::{Deref, DerefMut};
 
@@ -33,7 +33,7 @@ impl Plugin for MinePlugin {
             .add_event::<StopMiningBlockEvent>()
             .add_event::<MineBlockProgressEvent>()
             .add_event::<AttackBlockEvent>()
-            .add_systems(FixedUpdate, continue_mining_block.before(PhysicsSet))
+            .add_systems(GameTick, continue_mining_block.before(PhysicsSet))
             .add_systems(
                 Update,
                 (

--- a/azalea-client/src/movement.rs
+++ b/azalea-client/src/movement.rs
@@ -1,6 +1,7 @@
 use crate::client::Client;
 use crate::packet_handling::game::SendPacketEvent;
 use azalea_core::position::Vec3;
+use azalea_core::tick::GameTick;
 use azalea_entity::{metadata::Sprinting, Attributes, Jumping};
 use azalea_entity::{InLoadedChunk, LastSentPosition, LookDirection, Physics, Position};
 use azalea_physics::{ai_step, PhysicsSet};
@@ -12,7 +13,7 @@ use azalea_protocol::packets::game::{
     serverbound_move_player_status_only_packet::ServerboundMovePlayerStatusOnlyPacket,
 };
 use azalea_world::{MinecraftEntityId, MoveEntityError};
-use bevy_app::{App, FixedUpdate, Plugin, Update};
+use bevy_app::{App, Plugin, Update};
 use bevy_ecs::prelude::{Event, EventWriter};
 use bevy_ecs::schedule::SystemSet;
 use bevy_ecs::{
@@ -54,7 +55,7 @@ impl Plugin for PlayerMovePlugin {
                     .in_set(MoveEventsSet),
             )
             .add_systems(
-                FixedUpdate,
+                GameTick,
                 (
                     (tick_controls, local_player_ai_step)
                         .chain()

--- a/azalea-core/Cargo.toml
+++ b/azalea-core/Cargo.toml
@@ -13,7 +13,7 @@ azalea-buf = { path = "../azalea-buf", version = "0.8.0" }
 azalea-inventory = { version = "0.8.0", path = "../azalea-inventory" }
 simdnbt = { version = "0.2.1" }
 azalea-registry = { path = "../azalea-registry", version = "0.8.0" }
-bevy_ecs = { version = "0.12.0", default-features = false, optional = true }
+bevy_ecs = { version = "0.12.1", default-features = false, optional = true }
 nohash-hasher = "0.2.0"
 num-traits = "0.2.17"
 serde = { version = "^1.0", optional = true }

--- a/azalea-core/src/lib.rs
+++ b/azalea-core/src/lib.rs
@@ -16,4 +16,5 @@ pub mod particle;
 pub mod position;
 pub mod registry_holder;
 pub mod resource_location;
+pub mod tick;
 pub mod tier;

--- a/azalea-core/src/tick.rs
+++ b/azalea-core/src/tick.rs
@@ -1,0 +1,4 @@
+use bevy_ecs::schedule::ScheduleLabel;
+
+#[derive(ScheduleLabel, Hash, Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct GameTick;

--- a/azalea-entity/Cargo.toml
+++ b/azalea-entity/Cargo.toml
@@ -17,8 +17,8 @@ azalea-inventory = { version = "0.8.0", path = "../azalea-inventory" }
 simdnbt = { version = "0.2.1" }
 azalea-registry = { version = "0.8.0", path = "../azalea-registry" }
 azalea-world = { version = "0.8.0", path = "../azalea-world" }
-bevy_app = "0.12.0"
-bevy_ecs = "0.12.0"
+bevy_app = "0.12.1"
+bevy_ecs = "0.12.1"
 derive_more = "0.99.17"
 enum-as-inner = "0.6.0"
 tracing = "0.1.40"

--- a/azalea-physics/Cargo.toml
+++ b/azalea-physics/Cargo.toml
@@ -15,12 +15,12 @@ azalea-entity = { version = "0.8.0", path = "../azalea-entity" }
 azalea-inventory = { version = "0.8.0", path = "../azalea-inventory" }
 azalea-registry = { path = "../azalea-registry", version = "0.8.0" }
 azalea-world = { path = "../azalea-world", version = "0.8.0" }
-bevy_app = "0.12.0"
-bevy_ecs = "0.12.0"
+bevy_app = "0.12.1"
+bevy_ecs = "0.12.1"
 tracing = "0.1.40"
 once_cell = "1.18.0"
 parking_lot = "^0.12.1"
 
 [dev-dependencies]
-bevy_time = "0.12.0"
+bevy_time = "0.12.1"
 uuid = "^1.5.0"

--- a/azalea-physics/src/lib.rs
+++ b/azalea-physics/src/lib.rs
@@ -9,13 +9,14 @@ use azalea_block::{Block, BlockState};
 use azalea_core::{
     math,
     position::{BlockPos, Vec3},
+    tick::GameTick,
 };
 use azalea_entity::{
     metadata::Sprinting, move_relative, Attributes, InLoadedChunk, Jumping, LocalEntity,
     LookDirection, Physics, Position,
 };
 use azalea_world::{Instance, InstanceContainer, InstanceName};
-use bevy_app::{App, FixedUpdate, Plugin};
+use bevy_app::{App, Plugin};
 use bevy_ecs::{
     query::With,
     schedule::{IntoSystemConfigs, SystemSet},
@@ -32,7 +33,7 @@ pub struct PhysicsPlugin;
 impl Plugin for PhysicsPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
-            FixedUpdate,
+            GameTick,
             (ai_step, travel)
                 .chain()
                 .in_set(PhysicsSet)
@@ -335,21 +336,18 @@ fn jump_boost_power() -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
 
     use super::*;
-    use azalea_core::{position::ChunkPos, resource_location::ResourceLocation};
+    use azalea_core::{position::ChunkPos, resource_location::ResourceLocation, tick::GameTick};
     use azalea_entity::{EntityBundle, EntityPlugin};
     use azalea_world::{Chunk, MinecraftEntityId, PartialInstance};
     use bevy_app::App;
-    use bevy_time::{Fixed, Time};
     use uuid::Uuid;
 
     /// You need an app to spawn entities in the world and do updates.
     fn make_test_app() -> App {
         let mut app = App::new();
         app.add_plugins((PhysicsPlugin, EntityPlugin))
-            .insert_resource(Time::<Fixed>::from_duration(Duration::from_millis(50)))
             .init_resource::<InstanceContainer>();
         app
     }
@@ -393,7 +391,7 @@ mod tests {
             assert_eq!(entity_pos.y, 70.);
         }
         app.update();
-        app.world.run_schedule(FixedUpdate);
+        app.world.run_schedule(GameTick);
         app.update();
         {
             let entity_pos = *app.world.get::<Position>(entity).unwrap();
@@ -402,7 +400,7 @@ mod tests {
             let entity_physics = app.world.get::<Physics>(entity).unwrap();
             assert!(entity_physics.velocity.y < 0.);
         }
-        app.world.run_schedule(FixedUpdate);
+        app.world.run_schedule(GameTick);
         app.update();
         {
             let entity_pos = *app.world.get::<Position>(entity).unwrap();
@@ -456,7 +454,7 @@ mod tests {
             "Block state should exist, if this fails that means the chunk wasn't loaded and the block didn't get placed"
         );
         app.update();
-        app.world.run_schedule(FixedUpdate);
+        app.world.run_schedule(GameTick);
         app.update();
         {
             let entity_pos = *app.world.get::<Position>(entity).unwrap();
@@ -465,7 +463,7 @@ mod tests {
             let entity_physics = app.world.get::<Physics>(entity).unwrap();
             assert!(entity_physics.velocity.y < 0.);
         }
-        app.world.run_schedule(FixedUpdate);
+        app.world.run_schedule(GameTick);
         app.update();
         {
             let entity_pos = *app.world.get::<Position>(entity).unwrap();
@@ -521,7 +519,7 @@ mod tests {
         );
         // do a few steps so we fall on the slab
         for _ in 0..20 {
-            app.world.run_schedule(FixedUpdate);
+            app.world.run_schedule(GameTick);
             app.update();
         }
         let entity_pos = app.world.get::<Position>(entity).unwrap();
@@ -574,7 +572,7 @@ mod tests {
         );
         // do a few steps so we fall on the slab
         for _ in 0..20 {
-            app.world.run_schedule(FixedUpdate);
+            app.world.run_schedule(GameTick);
             app.update();
         }
         let entity_pos = app.world.get::<Position>(entity).unwrap();
@@ -631,7 +629,7 @@ mod tests {
         );
         // do a few steps so we fall on the wall
         for _ in 0..20 {
-            app.world.run_schedule(FixedUpdate);
+            app.world.run_schedule(GameTick);
             app.update();
         }
 
@@ -693,7 +691,7 @@ mod tests {
         );
         // do a few steps so we fall on the wall
         for _ in 0..20 {
-            app.world.run_schedule(FixedUpdate);
+            app.world.run_schedule(GameTick);
             app.update();
         }
 

--- a/azalea-protocol/Cargo.toml
+++ b/azalea-protocol/Cargo.toml
@@ -27,7 +27,7 @@ simdnbt = { version = "0.2.1" }
 azalea-protocol-macros = { path = "./azalea-protocol-macros", version = "0.8.0" }
 azalea-registry = { path = "../azalea-registry", version = "0.8.0" }
 azalea-world = { path = "../azalea-world", version = "0.8.0" }
-bevy_ecs = { version = "0.12.0", default-features = false }
+bevy_ecs = { version = "0.12.1", default-features = false }
 byteorder = "^1.5.0"
 bytes = "^1.5.0"
 flate2 = "1.0.28"

--- a/azalea-world/Cargo.toml
+++ b/azalea-world/Cargo.toml
@@ -17,7 +17,7 @@ azalea-core = { path = "../azalea-core", version = "^0.8.0", features = [
 azalea-inventory = { version = "0.8.0", path = "../azalea-inventory" }
 simdnbt = { version = "0.2.1" }
 azalea-registry = { path = "../azalea-registry", version = "0.8.0" }
-bevy_ecs = "0.12.0"
+bevy_ecs = "0.12.1"
 derive_more = { version = "0.99.17", features = ["deref", "deref_mut"] }
 enum-as-inner = "0.6.0"
 tracing = "0.1.40"

--- a/azalea/Cargo.toml
+++ b/azalea/Cargo.toml
@@ -26,9 +26,9 @@ azalea-world = { version = "0.8.0", path = "../azalea-world" }
 azalea-auth = { version = "0.8.0", path = "../azalea-auth" }
 azalea-brigadier = { version = "0.8.0", path = "../azalea-brigadier" }
 azalea-buf = { version = "0.8.0", path = "../azalea-buf" }
-bevy_app = "0.12.0"
-bevy_ecs = "0.12.0"
-bevy_tasks = { version = "0.12.0", features = ["multi-threaded"] }
+bevy_app = "0.12.1"
+bevy_ecs = "0.12.1"
+bevy_tasks = { version = "0.12.1", features = ["multi-threaded"] }
 derive_more = { version = "0.99.17", features = ["deref", "deref_mut"] }
 futures = "0.3.29"
 futures-lite = "2.0.1"
@@ -40,9 +40,9 @@ priority-queue = "1.3.2"
 thiserror = "^1.0.50"
 tokio = "^1.34.0"
 uuid = "1.5.0"
-bevy_log = "0.12.0"
+bevy_log = "0.12.1"
 azalea-entity = { version = "0.8.0", path = "../azalea-entity" }
-bevy_time = "0.12.0"
+bevy_time = "0.12.1"
 rustc-hash = "1.1.0"
 
 [dev-dependencies]

--- a/azalea/examples/nearest_entity.rs
+++ b/azalea/examples/nearest_entity.rs
@@ -2,9 +2,10 @@ use azalea::nearest_entity::EntityFinder;
 use azalea::ClientBuilder;
 use azalea::{Bot, LookAtEvent};
 use azalea_client::Account;
+use azalea_core::tick::GameTick;
 use azalea_entity::metadata::{ItemItem, Player};
 use azalea_entity::{EyeHeight, LocalEntity, Position};
-use bevy_app::{FixedUpdate, Plugin};
+use bevy_app::Plugin;
 use bevy_ecs::{
     prelude::{Entity, EventWriter},
     query::With,
@@ -25,7 +26,7 @@ async fn main() {
 pub struct LookAtStuffPlugin;
 impl Plugin for LookAtStuffPlugin {
     fn build(&self, app: &mut bevy_app::App) {
-        app.add_systems(FixedUpdate, (look_at_everything, log_nearby_item_drops));
+        app.add_systems(GameTick, (look_at_everything, log_nearby_item_drops));
     }
 }
 

--- a/azalea/src/bot.rs
+++ b/azalea/src/bot.rs
@@ -13,12 +13,13 @@ use azalea_client::interact::SwingArmEvent;
 use azalea_client::mining::Mining;
 use azalea_client::TickBroadcast;
 use azalea_core::position::{BlockPos, Vec3};
+use azalea_core::tick::GameTick;
 use azalea_entity::{
     clamp_look_direction, metadata::Player, EyeHeight, Jumping, LocalEntity, LookDirection,
     Position,
 };
 use azalea_physics::PhysicsSet;
-use bevy_app::{FixedUpdate, Update};
+use bevy_app::Update;
 use bevy_ecs::prelude::Event;
 use bevy_ecs::schedule::IntoSystemConfigs;
 use futures_lite::Future;
@@ -41,7 +42,7 @@ impl Plugin for BotPlugin {
                     jump_listener,
                 ),
             )
-            .add_systems(FixedUpdate, stop_jumping.after(PhysicsSet));
+            .add_systems(GameTick, stop_jumping.after(PhysicsSet));
     }
 }
 

--- a/azalea/src/pathfinder/mod.rs
+++ b/azalea/src/pathfinder/mod.rs
@@ -28,12 +28,13 @@ use azalea_client::inventory::{InventoryComponent, InventorySet};
 use azalea_client::movement::MoveEventsSet;
 use azalea_client::{StartSprintEvent, StartWalkEvent};
 use azalea_core::position::{BlockPos, Vec3};
+use azalea_core::tick::GameTick;
 use azalea_entity::metadata::Player;
 use azalea_entity::LocalEntity;
 use azalea_entity::{Physics, Position};
 use azalea_physics::PhysicsSet;
 use azalea_world::{InstanceContainer, InstanceName};
-use bevy_app::{FixedUpdate, PreUpdate, Update};
+use bevy_app::{PreUpdate, Update};
 use bevy_ecs::event::Events;
 use bevy_ecs::prelude::Event;
 use bevy_ecs::query::Changed;
@@ -58,9 +59,9 @@ impl Plugin for PathfinderPlugin {
             .add_event::<PathFoundEvent>()
             .add_event::<StopPathfindingEvent>()
             .add_systems(
-                // putting systems in the FixedUpdate schedule makes them run every Minecraft tick
+                // putting systems in the GameTick schedule makes them run every Minecraft tick
                 // (every 50 milliseconds).
-                FixedUpdate,
+                GameTick,
                 (
                     timeout_movement,
                     check_node_reached,

--- a/azalea/src/pathfinder/simulation.rs
+++ b/azalea/src/pathfinder/simulation.rs
@@ -1,19 +1,18 @@
 //! Simulate the Minecraft world, currently only used for tests.
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use azalea_client::{
     inventory::InventoryComponent, packet_handling::game::SendPacketEvent, PhysicsState,
 };
-use azalea_core::{position::Vec3, resource_location::ResourceLocation};
+use azalea_core::{position::Vec3, resource_location::ResourceLocation, tick::GameTick};
 use azalea_entity::{
     attributes::AttributeInstance, metadata::Sprinting, Attributes, EntityDimensions, Physics,
     Position,
 };
 use azalea_world::{ChunkStorage, Instance, InstanceContainer, InstanceName, MinecraftEntityId};
-use bevy_app::{App, FixedUpdate};
+use bevy_app::App;
 use bevy_ecs::prelude::*;
-use bevy_time::{Fixed, Time};
 use parking_lot::RwLock;
 
 #[derive(Bundle, Clone)]
@@ -71,8 +70,6 @@ impl Simulation {
             crate::BotPlugin,
             azalea_client::task_pool::TaskPoolPlugin::default(),
         ))
-        // make sure it doesn't do fixed ticks without us telling it to
-        .insert_resource(Time::<Fixed>::from_duration(Duration::MAX))
         .insert_resource(InstanceContainer {
             instances: [(instance_name.clone(), Arc::downgrade(&instance.clone()))]
                 .iter()
@@ -107,7 +104,7 @@ impl Simulation {
         }
     }
     pub fn tick(&mut self) {
-        self.app.world.run_schedule(FixedUpdate);
+        self.app.world.run_schedule(GameTick);
         self.app.update();
     }
     pub fn position(&self) -> Vec3 {

--- a/azalea/src/prelude.rs
+++ b/azalea/src/prelude.rs
@@ -9,3 +9,4 @@ pub use azalea_client::{Account, Client, Event};
 // this is necessary to make the macros that reference bevy_ecs work
 pub use crate::ecs as bevy_ecs;
 pub use crate::ecs::{component::Component, system::Resource};
+pub use azalea_core::tick::GameTick;

--- a/azalea/src/swarm/mod.rs
+++ b/azalea/src/swarm/mod.rs
@@ -461,7 +461,7 @@ pub type BoxSwarmHandleFn<SS> =
 /// struct SwarmState {}
 ///
 /// #[tokio::main]
-/// async fn main() -> anyhow::Result<()> {
+/// async fn main() {
 ///     let mut accounts = Vec::new();
 ///     let mut states = Vec::new();
 ///


### PR DESCRIPTION
The `FixedUpdate` schedule can run multiple times in a row without `Update` running, which can cause weird bugs under high CPU usage. This change replaces `FixedUpdate` with our own schedule that we fully control, which I chose to put in `azalea_core::tick::GameTick` (and re-export in the azalea prelude). This will likely break some plugins, but it was probably going to have to happen at some point anyways so might as well rip the band-aid off now.

I implemented the change mostly with find-and-replace, so I may have overlooked things.
