### PR TITLE
Make get_mc_dir public

### DIFF
--- a/azalea-client/src/lib.rs
+++ b/azalea-client/src/lib.rs
@@ -16,7 +16,7 @@ mod client;
 pub mod disconnect;
 mod entity_query;
 mod events;
-mod get_mc_dir;
+pub mod get_mc_dir;
 pub mod interact;
 pub mod inventory;
 mod local_player;


### PR DESCRIPTION
Used in [doorstop](https://github.com/veronoicc/doorstop)