### PR TITLE
fix: GameOwnershipResponse key_id format

### DIFF
--- a/azalea-auth/src/auth.rs
+++ b/azalea-auth/src/auth.rs
@@ -238,6 +238,7 @@ pub struct MinecraftAuthResponse {
 pub struct GameOwnershipResponse {
     pub items: Vec<GameOwnershipItem>,
     pub signature: String,
+    #[serde(rename = "keyId")]
     pub key_id: String,
 }
 


### PR DESCRIPTION
Example:
```
{
  "items" : [ {
    "name" : "game_minecraft",
    "signature" : ""
  }, {
    "name" : "game_minecraft_bedrock",
    "signature" : ""
  }, {
    "name" : "product_minecraft",
    "signature" : ""
  }, {
    "name" : "product_minecraft_bedrock",
    "signature" : ""
  } ],
  "signature" : "",
  "keyId" : "1"
}
```