### PR TITLE
fix: Add missing `successful` field to `ServerboundCustomQueryAnswerPacket`

### DIFF
--- a/azalea-client/src/packet_handling/login.rs
+++ b/azalea-client/src/packet_handling/login.rs
@@ -90,6 +90,9 @@ pub fn process_packet_events(ecs: &mut World) {
                     entity: player_entity,
                     packet: ServerboundCustomQueryAnswerPacket {
                         transaction_id: p.transaction_id,
+                        // From https://wiki.vg/Protocol#Login_Plugin_Request:
+                        // > The notchian client always responds that it hasn't understood, and sends an empty payload.
+                        successful: false,
                         data: None,
                     }
                     .get(),

--- a/azalea-protocol/src/packets/login/serverbound_custom_query_answer_packet.rs
+++ b/azalea-protocol/src/packets/login/serverbound_custom_query_answer_packet.rs
@@ -6,5 +6,6 @@ use std::hash::Hash;
 pub struct ServerboundCustomQueryAnswerPacket {
     #[var]
     pub transaction_id: u32,
+    pub successful: bool,
     pub data: Option<UnsizedByteArray>,
 }

--- a/azalea-protocol/src/packets/login/serverbound_custom_query_packet.rs
+++ b/azalea-protocol/src/packets/login/serverbound_custom_query_packet.rs
@@ -1,9 +1,0 @@
-use azalea_buf::{McBuf, UnsizedByteArray};
-use azalea_protocol_macros::ServerboundLoginPacket;
-
-#[derive(Clone, Debug, McBuf, ServerboundLoginPacket)]
-pub struct ServerboundCustomQueryPacket {
-    #[var]
-    pub transaction_id: u32,
-    pub data: Option<UnsizedByteArray>,
-}


### PR DESCRIPTION
While working on my own Minecraft server (using azalea) and reading [wiki.vg/Protocol](https://wiki.vg/Protocol) a lot, I noticed that the `successful` field is not implemented in the `ServerboundCustomQueryAnswerPacket`, as described here: [wiki.vg/Protocol#Login_Plugin_Response](https://wiki.vg/Protocol#Login_Plugin_Response).

This PR adds the missing field and removes an unused packet (that's not mapped or used anywhere).