### PR TITLE
Fix command packets

### DIFF
--- a/azalea-client/src/chat.rs
+++ b/azalea-client/src/chat.rs
@@ -276,19 +276,7 @@ fn handle_send_chat_kind_event(
             .get(),
             ChatPacketKind::Command => {
                 // TODO: chat signing
-                ServerboundChatCommandPacket {
-                    command: content,
-                    timestamp: SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .expect("Time shouldn't be before epoch")
-                        .as_millis()
-                        .try_into()
-                        .expect("Instant should fit into a u64"),
-                    salt: azalea_crypto::make_salt(),
-                    argument_signatures: vec![],
-                    last_seen_messages: LastSeenMessagesUpdate::default(),
-                }
-                .get()
+                ServerboundChatCommandPacket { command: content }.get()
             }
         };
 

--- a/azalea-protocol/src/packets/game/serverbound_chat_command_packet.rs
+++ b/azalea-protocol/src/packets/game/serverbound_chat_command_packet.rs
@@ -1,19 +1,7 @@
-use super::serverbound_chat_packet::LastSeenMessagesUpdate;
 use azalea_buf::McBuf;
-use azalea_crypto::MessageSignature;
 use azalea_protocol_macros::ServerboundGamePacket;
 
 #[derive(Clone, Debug, McBuf, ServerboundGamePacket)]
 pub struct ServerboundChatCommandPacket {
     pub command: String,
-    pub timestamp: u64,
-    pub salt: u64,
-    pub argument_signatures: Vec<ArgumentSignature>,
-    pub last_seen_messages: LastSeenMessagesUpdate,
-}
-
-#[derive(Clone, Debug, McBuf)]
-pub struct ArgumentSignature {
-    pub name: String,
-    pub signature: MessageSignature,
 }


### PR DESCRIPTION
I finally tracked down, why commands don't work and cause the client to disconnect.

The packet has its contents copied from the "Signed" counterpart, which is unexpected. Thus most servers kick you for it.

This should address it.

Fixes https://github.com/azalea-rs/azalea-viaversion/issues/4