### PR TITLE
Added Left Click Mine Functionality

### DIFF
--- a/azalea-client/src/mining.rs
+++ b/azalea-client/src/mining.rs
@@ -1,6 +1,6 @@
 use azalea_block::{Block, BlockState, FluidState};
 use azalea_core::{direction::Direction, game_type::GameMode, position::BlockPos, tick::GameTick};
-use azalea_entity::{mining::get_mine_progress, FluidOnEyes, Physics, Position, LocalEntity};
+use azalea_entity::{mining::get_mine_progress, FluidOnEyes, Physics, LocalEntity};
 use azalea_inventory::ItemSlot;
 use azalea_physics::PhysicsSet;
 use azalea_protocol::packets::game::serverbound_player_action_packet::{
@@ -98,7 +98,6 @@ fn handle_auto_mine(
     mut query: Query<
         (
             &HitResultComponent,
-            &Position,
             Entity,
             Option<&Mining>,
             &InventoryComponent,
@@ -111,7 +110,6 @@ fn handle_auto_mine(
 ) {
     for (
         hit_result_component,
-        position,
         entity,
         mining,
         inventory,
@@ -121,14 +119,13 @@ fn handle_auto_mine(
     {
         let block_pos = hit_result_component.block_pos;
 
-        if (mining.is_none()
+        if mining.is_none()
             || !is_same_mining_target(
             block_pos,
             inventory,
             current_mining_pos,
             current_mining_item,
-        ))
-            && position.distance_to(&block_pos.to_vec3_floored()) <= 7.0
+        )
         {
             start_mining_block_event_writer.send(StartMiningBlockEvent {
                 entity,

--- a/azalea-client/src/mining.rs
+++ b/azalea-client/src/mining.rs
@@ -39,7 +39,7 @@ impl Plugin for MinePlugin {
                 GameTick,
                 (
                     continue_mining_block,
-                    handle_auto_mine
+                    handle_left_click_mine
                 )
                     .chain()
                     .before(PhysicsSet),
@@ -78,24 +78,23 @@ impl Client {
     }
 
     /// When enabled, the bot will mine any block that it is looking at if it is reachable.
-    /// By default, reachability is set to 5 blocks.
-    pub fn auto_mine(&self, enabled: bool) {
+    pub fn left_click_mine(&self, enabled: bool) {
         let mut ecs = self.ecs.lock();
         let mut entity_mut = ecs.entity_mut(self.entity);
 
         if enabled {
-            entity_mut.insert(AutoMine);
+            entity_mut.insert(LeftClickMine);
         } else {
-            entity_mut.remove::<AutoMine>();
+            entity_mut.remove::<LeftClickMine>();
         }
     }
 }
 
 #[derive(Component)]
-pub struct AutoMine;
+pub struct LeftClickMine;
 
 #[allow(clippy::type_complexity)]
-fn handle_auto_mine(
+fn handle_left_click_mine(
     mut query: Query<
         (
             &HitResultComponent,
@@ -105,7 +104,7 @@ fn handle_auto_mine(
             &MineBlockPos,
             &MineItem,
         ),
-        (With<AutoMine>, With<Player>, With<LocalEntity>),
+        (With<LeftClickMine>, With<Player>, With<LocalEntity>),
     >,
     mut start_mining_block_event: EventWriter<StartMiningBlockEvent>,
     mut stop_mining_block_event: EventWriter<StopMiningBlockEvent>

--- a/azalea-client/src/mining.rs
+++ b/azalea-client/src/mining.rs
@@ -94,6 +94,7 @@ impl Client {
 #[derive(Component)]
 pub struct AutoMine;
 
+#[allow(clippy::type_complexity)]
 fn handle_auto_mine(
     mut query: Query<
         (


### PR DESCRIPTION
## What this PR does?
This PR, will introduce a function in `azalea::Client` i.e. `left_click_mine`, once it is enabled it will make the bot mine the blocks it is looking at if it is within it's range In simpler words, it is a simple left-click implementation for mining blocks.

## Why this was added?
Although, it is quite basic functionality which could be used either for digging tunnels, mining stones in stone generator, etc. But I thought having it out of the box supported by azalea would be great, that's why I opened this PR.

## Why this PR was not opened on the main branch of azalea?
The main branch currently, supports Minecraft version `1.21` and introduces changes in `azalea-client/interact.rs` which interferes with `left_click_mine`. This [issue](https://discord.com/channels/1041923016856191016/1041923017317548064/1252128882971246612) makes `left_click_mine` not work in `1.21`. But I am working on a fix, and will soon open a PR to the main branch.