### PR TITLE
Auth Customization Options

### DIFF
--- a/azalea-auth/examples/auth_manual.rs
+++ b/azalea-auth/examples/auth_manual.rs
@@ -23,12 +23,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn auth() -> Result<ProfileResponse, Box<dyn Error>> {
     let client = reqwest::Client::new();
 
-    let res = azalea_auth::get_ms_link_code(&client, CLIENT_ID, SCOPE).await?;
+    let res = azalea_auth::get_ms_link_code(&client, None, None).await?;
     println!(
         "Go to {} and enter the code {}",
         res.verification_uri, res.user_code
     );
-    let msa = azalea_auth::get_ms_auth_token(&client, res, CLIENT_ID).await?;
+    let msa = azalea_auth::get_ms_auth_token(&client, res, None).await?;
     let auth_result = azalea_auth::get_minecraft_token(&client, &msa.data.access_token).await?;
     Ok(azalea_auth::get_profile(&client, &auth_result.minecraft_access_token).await?)
 }

--- a/azalea-auth/examples/auth_manual.rs
+++ b/azalea-auth/examples/auth_manual.rs
@@ -19,7 +19,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 // We will be using default `client_id` and `scope`
-// If you want to use your own replace `CLIENT_ID` and `SCOPE` with your own.
 async fn auth() -> Result<ProfileResponse, Box<dyn Error>> {
     let client = reqwest::Client::new();
 
@@ -32,6 +31,3 @@ async fn auth() -> Result<ProfileResponse, Box<dyn Error>> {
     let auth_result = azalea_auth::get_minecraft_token(&client, &msa.data.access_token).await?;
     Ok(azalea_auth::get_profile(&client, &auth_result.minecraft_access_token).await?)
 }
-
-const CLIENT_ID: &str = "00000000441cc96b";
-const SCOPE: &str = "service::user.auth.xboxlive.com::MBI_SSL";

--- a/azalea-auth/examples/auth_manual.rs
+++ b/azalea-auth/examples/auth_manual.rs
@@ -18,15 +18,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+// We will be using default `client_id` and `scope`
+// If you want to use your own replace `CLIENT_ID` and `SCOPE` with your own.
 async fn auth() -> Result<ProfileResponse, Box<dyn Error>> {
     let client = reqwest::Client::new();
 
-    let res = azalea_auth::get_ms_link_code(&client).await?;
+    let res = azalea_auth::get_ms_link_code(&client, CLIENT_ID, SCOPE).await?;
     println!(
         "Go to {} and enter the code {}",
         res.verification_uri, res.user_code
     );
-    let msa = azalea_auth::get_ms_auth_token(&client, res).await?;
+    let msa = azalea_auth::get_ms_auth_token(&client, res, CLIENT_ID).await?;
     let auth_result = azalea_auth::get_minecraft_token(&client, &msa.data.access_token).await?;
     Ok(azalea_auth::get_profile(&client, &auth_result.minecraft_access_token).await?)
 }
+
+const CLIENT_ID: &str = "00000000441cc96b";
+const SCOPE: &str = "service::user.auth.xboxlive.com::MBI_SSL";

--- a/azalea-auth/src/auth.rs
+++ b/azalea-auth/src/auth.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use uuid::Uuid;
 
 #[derive(Default)]
-pub struct AuthOpts {
+pub struct AuthOpts<'a> {
     /// Whether we should check if the user actually owns the game. This will
     /// fail if the user has Xbox Game Pass! Note that this isn't really
     /// necessary, since getting the user profile will check this anyways.
@@ -25,9 +25,9 @@ pub struct AuthOpts {
     /// done.
     pub cache_file: Option<PathBuf>,
     /// If you choose to use your own microsoft authentication instead of using nintendo switch, just put your client_id here
-    pub client_id: Option<&'static str>,
+    pub client_id: Option<&'a str>,
     /// If you want to use custom scope instead of default one
-    pub scope: Option<&'static str>
+    pub scope: Option<&'a str>
 }
 
 #[derive(Debug, Error)]
@@ -63,7 +63,7 @@ pub enum AuthError {
 /// If you want to use your own code to cache or show the auth code to the user
 /// in a different way, use [`get_ms_link_code`], [`get_ms_auth_token`],
 /// [`get_minecraft_token`] and [`get_profile`] instead.
-pub async fn auth(email: &str, opts: AuthOpts) -> Result<AuthResult, AuthError> {
+pub async fn auth<'a>(email: &str, opts: AuthOpts<'a>) -> Result<AuthResult, AuthError> {
     let cached_account = if let Some(cache_file) = &opts.cache_file {
         cache::get_account_in_cache(cache_file, email).await
     } else {

--- a/azalea-auth/src/auth.rs
+++ b/azalea-auth/src/auth.rs
@@ -357,7 +357,7 @@ pub async fn get_ms_auth_token(
         tokio::time::sleep(std::time::Duration::from_secs(res.interval)).await;
 
         tracing::trace!("Polling to check if user has logged in...");
-        if let Ok(mut access_token_response) = client
+        if let Ok(access_token_response) = client
             .post(format!(
                 "https://login.live.com/oauth20_token.srf?client_id={client_id}"
             ))

--- a/azalea-auth/src/auth.rs
+++ b/azalea-auth/src/auth.rs
@@ -24,9 +24,9 @@ pub struct AuthOpts<'a> {
     /// The directory to store the cache in. If this is not set, caching is not
     /// done.
     pub cache_file: Option<PathBuf>,
-    /// If you choose to use your own microsoft authentication instead of using nintendo switch, just put your client_id here
+    /// If you choose to use your own Microsoft authentication instead of using Nintendo Switch, just put your client_id here.
     pub client_id: Option<&'a str>,
-    /// If you want to use custom scope instead of default one
+    /// If you want to use custom scope instead of default one, just put your scope here.
     pub scope: Option<&'a str>
 }
 

--- a/azalea-auth/src/auth.rs
+++ b/azalea-auth/src/auth.rs
@@ -389,7 +389,7 @@ pub enum RefreshMicrosoftAuthTokenError {
 pub async fn refresh_ms_auth_token(
     client: &reqwest::Client,
     refresh_token: &str,
-    client_id: Option<&str>
+    client_id: Option<&'static str>
 ) -> Result<ExpiringValue<AccessTokenResponse>, RefreshMicrosoftAuthTokenError> {
     let client_id = if client_id.is_some() {
         client_id.unwrap()
@@ -401,7 +401,7 @@ pub async fn refresh_ms_auth_token(
         .post("https://login.live.com/oauth20_token.srf")
         .form(&vec![
             ("scope", "service::user.auth.xboxlive.com::MBI_SSL"),
-            ("client_id", client_id.unwrap()),
+            ("client_id", client_id),
             ("grant_type", "refresh_token"),
             ("refresh_token", refresh_token),
         ])

--- a/azalea-auth/src/auth.rs
+++ b/azalea-auth/src/auth.rs
@@ -24,7 +24,7 @@ pub struct AuthOpts {
     /// The directory to store the cache in. If this is not set, caching is not
     /// done.
     pub cache_file: Option<PathBuf>,
-    pub scope: Option<&'static str>,
+    /// If you choose to use your own microsoft authentication instead of using nintendo switch, just put your client_id here
     pub client_id: Option<&'static str>
 }
 
@@ -62,10 +62,6 @@ pub enum AuthError {
 /// in a different way, use [`get_ms_link_code`], [`get_ms_auth_token`],
 /// [`get_minecraft_token`] and [`get_profile`] instead.
 pub async fn auth(email: &str, opts: AuthOpts) -> Result<AuthResult, AuthError> {
-    if !((opts.scope.is_some() && opts.client_id.is_some()) || (opts.scope.is_none() && opts.client_id.is_none())) {
-        panic!("Either provide both `scope` and `client_id` or nether.")
-    }
-
     let cached_account = if let Some(cache_file) = &opts.cache_file {
         cache::get_account_in_cache(cache_file, email).await
     } else {
@@ -86,16 +82,16 @@ pub async fn auth(email: &str, opts: AuthOpts) -> Result<AuthResult, AuthError> 
         let mut msa = if let Some(account) = cached_account {
             account.msa
         } else {
-            interactive_get_ms_auth_token(&client, email, opts.scope, opts.client_id).await?
+            interactive_get_ms_auth_token(&client, email, opts.client_id).await?
         };
         if msa.is_expired() {
             tracing::trace!("refreshing Microsoft auth token");
-            match refresh_ms_auth_token(&client, &msa.data.refresh_token, opts.scope, opts.client_id).await {
+            match refresh_ms_auth_token(&client, &msa.data.refresh_token, opts.client_id).await {
                 Ok(new_msa) => msa = new_msa,
                 Err(e) => {
                     // can't refresh, ask the user to auth again
                     tracing::error!("Error refreshing Microsoft auth token: {}", e);
-                    msa = interactive_get_ms_auth_token(&client, email, opts.scope, opts.client_id).await?;
+                    msa = interactive_get_ms_auth_token(&client, email, opts.client_id).await?;
                 }
             }
         }
@@ -286,7 +282,7 @@ pub enum GetMicrosoftAuthTokenError {
 ///
 /// ```
 /// # async fn example(client: &reqwest::Client) -> Result<(), Box<dyn std::error::Error>> {
-/// let res = azalea_auth::get_ms_link_code(&client, None, None).await?;
+/// let res = azalea_auth::get_ms_link_code(&client, None).await?;
 /// println!(
 ///     "Go to {} and enter the code {}",
 ///     res.verification_uri, res.user_code
@@ -299,19 +295,18 @@ pub enum GetMicrosoftAuthTokenError {
 /// ```
 pub async fn get_ms_link_code(
     client: &reqwest::Client,
-    scope: Option<&str>,
     client_id: Option<&str>
 ) -> Result<DeviceCodeResponse, GetMicrosoftAuthTokenError> {
-    let (scope, client_id) = if scope.is_some() && client_id.is_some() {
-        (scope.unwrap(), client_id.unwrap())
+    let client_id = if client_id.is_some() {
+        client_id.unwrap()
     } else {
-        ("service::user.auth.xboxlive.com::MBI_SSL", CLIENT_ID)
+        CLIENT_ID
     };
 
     Ok(client
         .post("https://login.live.com/oauth20_connect.srf")
         .form(&vec![
-            ("scope", scope),
+            ("scope", "service::user.auth.xboxlive.com::MBI_SSL"),
             ("client_id", client_id),
             ("response_type", "device_code"),
         ])
@@ -371,10 +366,9 @@ pub async fn get_ms_auth_token(
 pub async fn interactive_get_ms_auth_token(
     client: &reqwest::Client,
     email: &str,
-    scope: Option<&str>,
     client_id: Option<&str>
 ) -> Result<ExpiringValue<AccessTokenResponse>, GetMicrosoftAuthTokenError> {
-    let res = get_ms_link_code(client, scope, client_id).await?;
+    let res = get_ms_link_code(client, client_id).await?;
     tracing::trace!("Device code response: {:?}", res);
     println!(
         "Go to \x1b[1m{}\x1b[m and enter the code \x1b[1m{}\x1b[m for \x1b[1m{}\x1b[m",
@@ -395,36 +389,26 @@ pub enum RefreshMicrosoftAuthTokenError {
 pub async fn refresh_ms_auth_token(
     client: &reqwest::Client,
     refresh_token: &str,
-    scope: Option<&str>,
     client_id: Option<&str>
 ) -> Result<ExpiringValue<AccessTokenResponse>, RefreshMicrosoftAuthTokenError> {
-    let access_token_response_text = if scope.is_some() && client_id.is_some() {
-        client
-            .post("https://login.live.com/oauth20_token.srf")
-            .form(&vec![
-                ("scope", scope.unwrap()),
-                ("client_id", client_id.unwrap()),
-                ("grant_type", "refresh_token"),
-                ("refresh_token", refresh_token),
-            ])
-            .send()
-            .await?
-            .text()
-            .await?
+    let client_id = if client_id.is_some() {
+        client_id.unwrap()
     } else {
-        client
-            .post("https://login.live.com/oauth20_token.srf")
-            .form(&vec![
-                ("scope", "service::user.auth.xboxlive.com::MBI_SSL"),
-                ("client_id", CLIENT_ID),
-                ("grant_type", "refresh_token"),
-                ("refresh_token", refresh_token),
-            ])
-            .send()
-            .await?
-            .text()
-            .await?
+        CLIENT_ID
     };
+
+    let access_token_response_text = client
+        .post("https://login.live.com/oauth20_token.srf")
+        .form(&vec![
+            ("scope", "service::user.auth.xboxlive.com::MBI_SSL"),
+            ("client_id", client_id.unwrap()),
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token),
+        ])
+        .send()
+        .await?
+        .text()
+        .await?;
     let access_token_response: AccessTokenResponse =
         serde_json::from_str(&access_token_response_text)?;
 

--- a/azalea-auth/src/auth.rs
+++ b/azalea-auth/src/auth.rs
@@ -24,6 +24,8 @@ pub struct AuthOpts {
     /// The directory to store the cache in. If this is not set, caching is not
     /// done.
     pub cache_file: Option<PathBuf>,
+    pub scope: Option<&'static str>,
+    pub client_id: Option<&'static str>
 }
 
 #[derive(Debug, Error)]
@@ -60,6 +62,10 @@ pub enum AuthError {
 /// in a different way, use [`get_ms_link_code`], [`get_ms_auth_token`],
 /// [`get_minecraft_token`] and [`get_profile`] instead.
 pub async fn auth(email: &str, opts: AuthOpts) -> Result<AuthResult, AuthError> {
+    if !((opts.scope.is_some() && opts.client_id.is_some()) || (opts.scope.is_none() && opts.client_id.is_none())) {
+        panic!("Either provide both `scope` and `client_id` or nether.")
+    }
+
     let cached_account = if let Some(cache_file) = &opts.cache_file {
         cache::get_account_in_cache(cache_file, email).await
     } else {
@@ -80,16 +86,16 @@ pub async fn auth(email: &str, opts: AuthOpts) -> Result<AuthResult, AuthError> 
         let mut msa = if let Some(account) = cached_account {
             account.msa
         } else {
-            interactive_get_ms_auth_token(&client, email).await?
+            interactive_get_ms_auth_token(&client, email, opts.scope, opts.client_id).await?
         };
         if msa.is_expired() {
             tracing::trace!("refreshing Microsoft auth token");
-            match refresh_ms_auth_token(&client, &msa.data.refresh_token).await {
+            match refresh_ms_auth_token(&client, &msa.data.refresh_token, opts.scope, opts.client_id).await {
                 Ok(new_msa) => msa = new_msa,
                 Err(e) => {
                     // can't refresh, ask the user to auth again
                     tracing::error!("Error refreshing Microsoft auth token: {}", e);
-                    msa = interactive_get_ms_auth_token(&client, email).await?;
+                    msa = interactive_get_ms_auth_token(&client, email, opts.scope, opts.client_id).await?;
                 }
             }
         }
@@ -280,7 +286,7 @@ pub enum GetMicrosoftAuthTokenError {
 ///
 /// ```
 /// # async fn example(client: &reqwest::Client) -> Result<(), Box<dyn std::error::Error>> {
-/// let res = azalea_auth::get_ms_link_code(&client).await?;
+/// let res = azalea_auth::get_ms_link_code(&client, None, None).await?;
 /// println!(
 ///     "Go to {} and enter the code {}",
 ///     res.verification_uri, res.user_code
@@ -293,12 +299,20 @@ pub enum GetMicrosoftAuthTokenError {
 /// ```
 pub async fn get_ms_link_code(
     client: &reqwest::Client,
+    scope: Option<&str>,
+    client_id: Option<&str>
 ) -> Result<DeviceCodeResponse, GetMicrosoftAuthTokenError> {
+    let (scope, client_id) = if scope.is_some() && client_id.is_some() {
+        (scope.unwrap(), client_id.unwrap())
+    } else {
+        ("service::user.auth.xboxlive.com::MBI_SSL", CLIENT_ID)
+    };
+
     Ok(client
         .post("https://login.live.com/oauth20_connect.srf")
         .form(&vec![
-            ("scope", "service::user.auth.xboxlive.com::MBI_SSL"),
-            ("client_id", CLIENT_ID),
+            ("scope", scope),
+            ("client_id", client_id),
             ("response_type", "device_code"),
         ])
         .send()
@@ -357,8 +371,10 @@ pub async fn get_ms_auth_token(
 pub async fn interactive_get_ms_auth_token(
     client: &reqwest::Client,
     email: &str,
+    scope: Option<&str>,
+    client_id: Option<&str>
 ) -> Result<ExpiringValue<AccessTokenResponse>, GetMicrosoftAuthTokenError> {
-    let res = get_ms_link_code(client).await?;
+    let res = get_ms_link_code(client, scope, client_id).await?;
     tracing::trace!("Device code response: {:?}", res);
     println!(
         "Go to \x1b[1m{}\x1b[m and enter the code \x1b[1m{}\x1b[m for \x1b[1m{}\x1b[m",
@@ -379,19 +395,36 @@ pub enum RefreshMicrosoftAuthTokenError {
 pub async fn refresh_ms_auth_token(
     client: &reqwest::Client,
     refresh_token: &str,
+    scope: Option<&str>,
+    client_id: Option<&str>
 ) -> Result<ExpiringValue<AccessTokenResponse>, RefreshMicrosoftAuthTokenError> {
-    let access_token_response_text = client
-        .post("https://login.live.com/oauth20_token.srf")
-        .form(&vec![
-            ("scope", "service::user.auth.xboxlive.com::MBI_SSL"),
-            ("client_id", CLIENT_ID),
-            ("grant_type", "refresh_token"),
-            ("refresh_token", refresh_token),
-        ])
-        .send()
-        .await?
-        .text()
-        .await?;
+    let access_token_response_text = if scope.is_some() && client_id.is_some() {
+        client
+            .post("https://login.live.com/oauth20_token.srf")
+            .form(&vec![
+                ("scope", scope.unwrap()),
+                ("client_id", client_id.unwrap()),
+                ("grant_type", "refresh_token"),
+                ("refresh_token", refresh_token),
+            ])
+            .send()
+            .await?
+            .text()
+            .await?
+    } else {
+        client
+            .post("https://login.live.com/oauth20_token.srf")
+            .form(&vec![
+                ("scope", "service::user.auth.xboxlive.com::MBI_SSL"),
+                ("client_id", CLIENT_ID),
+                ("grant_type", "refresh_token"),
+                ("refresh_token", refresh_token),
+            ])
+            .send()
+            .await?
+            .text()
+            .await?
+    };
     let access_token_response: AccessTokenResponse =
         serde_json::from_str(&access_token_response_text)?;
 

--- a/azalea-auth/src/auth.rs
+++ b/azalea-auth/src/auth.rs
@@ -371,10 +371,6 @@ pub async fn get_ms_auth_token(
             .json::<AccessTokenResponse>()
             .await
         {
-            if client_id != CLIENT_ID {
-                access_token_response.access_token.insert_str(0, "d=");
-            }
-
             tracing::trace!("access_token_response: {:?}", access_token_response);
             let expires_at = SystemTime::now()
                 + std::time::Duration::from_secs(access_token_response.expires_in);

--- a/azalea-client/src/account.rs
+++ b/azalea-client/src/account.rs
@@ -93,10 +93,15 @@ impl Account {
         Self::microsoft_with_custom_client_id_and_scope(email, None, None).await
     }
 
-    /// Similar to [`account.microsoft()`](Self::microsoft) but you can use your own `client_id` and `scope`.
+    /// Similar to [`account.microsoft()`](Self::microsoft) but you can use your
+    /// own `client_id` and `scope`.
     ///
     /// Pass `None` if you want to use default ones.
-    pub async fn microsoft_with_custom_client_id_and_scope(email: &str, client_id: Option<&str>, scope: Option<&str>) -> Result<Self, azalea_auth::AuthError> {
+    pub async fn microsoft_with_custom_client_id_and_scope(
+        email: &str,
+        client_id: Option<&str>,
+        scope: Option<&str>,
+    ) -> Result<Self, azalea_auth::AuthError> {
         let minecraft_dir = minecraft_folder_path::minecraft_dir().unwrap_or_else(|| {
             panic!(
                 "No {} environment variable found",
@@ -150,22 +155,29 @@ impl Account {
     /// # }
     /// ```
     pub async fn with_microsoft_access_token(
-        msa: azalea_auth::cache::ExpiringValue<AccessTokenResponse>
+        msa: azalea_auth::cache::ExpiringValue<AccessTokenResponse>,
     ) -> Result<Self, azalea_auth::AuthError> {
         Self::with_microsoft_access_token_and_custom_client_id_and_scope(msa, None, None).await
     }
 
-    /// Similar to [`Account::with_microsoft_access_token`] but you can use custom `client_id` and `scope`.
+    /// Similar to [`Account::with_microsoft_access_token`] but you can use
+    /// custom `client_id` and `scope`.
     pub async fn with_microsoft_access_token_and_custom_client_id_and_scope(
         mut msa: azalea_auth::cache::ExpiringValue<AccessTokenResponse>,
         client_id: Option<&str>,
-        scope: Option<&str>
+        scope: Option<&str>,
     ) -> Result<Self, azalea_auth::AuthError> {
         let client = reqwest::Client::new();
 
         if msa.is_expired() {
             tracing::trace!("refreshing Microsoft auth token");
-            msa = azalea_auth::refresh_ms_auth_token(&client, &msa.data.refresh_token, client_id, scope).await?;
+            msa = azalea_auth::refresh_ms_auth_token(
+                &client,
+                &msa.data.refresh_token,
+                client_id,
+                scope,
+            )
+            .await?;
         }
 
         let msa_token = &msa.data.access_token;

--- a/azalea-client/src/account.rs
+++ b/azalea-client/src/account.rs
@@ -96,7 +96,7 @@ impl Account {
     /// Similar to [`account.microsoft()`](Self::microsoft) but you can use your own `client_id` and `scope`.
     ///
     /// Pass `None` if you want to use default ones.
-    pub async fn microsoft_with_custom_client_id_and_scope(email: &str, client_id: Option<&'static str>, scope: Option<&'static str>) -> Result<Self, azalea_auth::AuthError> {
+    pub async fn microsoft_with_custom_client_id_and_scope(email: &str, client_id: Option<&str>, scope: Option<&str>) -> Result<Self, azalea_auth::AuthError> {
         let minecraft_dir = minecraft_folder_path::minecraft_dir().unwrap_or_else(|| {
             panic!(
                 "No {} environment variable found",
@@ -158,8 +158,8 @@ impl Account {
     /// Similar to [`Account::with_microsoft_access_token`] but you can use custom `client_id` and `scope`.
     pub async fn with_microsoft_access_token_and_custom_client_id_and_scope(
         mut msa: azalea_auth::cache::ExpiringValue<AccessTokenResponse>,
-        client_id: Option<&'static str>,
-        scope: Option<&'static str>
+        client_id: Option<&str>,
+        scope: Option<&str>
     ) -> Result<Self, azalea_auth::AuthError> {
         let client = reqwest::Client::new();
 

--- a/azalea-client/src/account.rs
+++ b/azalea-client/src/account.rs
@@ -144,7 +144,7 @@ impl Account {
     ///     "Go to {} and enter the code {}",
     ///     res.verification_uri, res.user_code
     /// );
-    /// let msa = azalea_auth::get_ms_auth_token(&client, res, "client_id").await?;
+    /// let msa = azalea_auth::get_ms_auth_token(&client, res, None).await?;
     /// Account::with_microsoft_access_token(msa).await?;
     /// # Ok(())
     /// # }

--- a/azalea-client/src/account.rs
+++ b/azalea-client/src/account.rs
@@ -90,11 +90,13 @@ impl Account {
     /// a key for the cache, but it's recommended to use the real email to
     /// avoid confusion.
     pub async fn microsoft(email: &str) -> Result<Self, azalea_auth::AuthError> {
-        Self::microsoft_with_custom_client_id(email, None).await
+        Self::microsoft_with_custom_client_id_and_scope(email, None, None).await
     }
 
-    /// Similar to [`account.microsoft()`](Self::microsoft) but you can use your own `client_id`.
-    pub async fn microsoft_with_custom_client_id(email: &str, client_id: Option<&'static str>) -> Result<Self, azalea_auth::AuthError> {
+    /// Similar to [`account.microsoft()`](Self::microsoft) but you can use your own `client_id` and `scope`.
+    ///
+    /// Pass `None` if you want to use default ones.
+    pub async fn microsoft_with_custom_client_id_and_scope(email: &str, client_id: Option<&'static str>, scope: Option<&'static str>) -> Result<Self, azalea_auth::AuthError> {
         let minecraft_dir = minecraft_folder_path::minecraft_dir().unwrap_or_else(|| {
             panic!(
                 "No {} environment variable found",
@@ -106,6 +108,7 @@ impl Account {
             azalea_auth::AuthOpts {
                 cache_file: Some(minecraft_dir.join("azalea-auth.json")),
                 client_id,
+                scope,
                 ..Default::default()
             },
         )
@@ -134,7 +137,7 @@ impl Account {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::Client::new();
     ///
-    /// let res = azalea_auth::get_ms_link_code(&client, None).await?;
+    /// let res = azalea_auth::get_ms_link_code(&client, "00000000441cc96b", "service::user. auth. xboxlive. com::MBI_SSL").await?;
     /// // Or, `azalea_auth::get_ms_link_code(&client, Some(client_id)).await?`
     /// // if you want to use your own client_id
     /// println!(
@@ -149,19 +152,20 @@ impl Account {
     pub async fn with_microsoft_access_token(
         msa: azalea_auth::cache::ExpiringValue<AccessTokenResponse>
     ) -> Result<Self, azalea_auth::AuthError> {
-        Self::with_microsoft_access_token_and_custom_client_id(msa, None).await
+        Self::with_microsoft_access_token_and_custom_client_id_and_scope(msa, None, None).await
     }
 
-    /// Similar to [`Account::with_microsoft_access_token`] but you can you custom `client_id`.
-    pub async fn with_microsoft_access_token_and_custom_client_id(
+    /// Similar to [`Account::with_microsoft_access_token`] but you can use custom `client_id` and `scope`.
+    pub async fn with_microsoft_access_token_and_custom_client_id_and_scope(
         mut msa: azalea_auth::cache::ExpiringValue<AccessTokenResponse>,
-        client_id: Option<&'static str>
+        client_id: Option<&'static str>,
+        scope: Option<&'static str>
     ) -> Result<Self, azalea_auth::AuthError> {
         let client = reqwest::Client::new();
 
         if msa.is_expired() {
             tracing::trace!("refreshing Microsoft auth token");
-            msa = azalea_auth::refresh_ms_auth_token(&client, &msa.data.refresh_token, client_id).await?;
+            msa = azalea_auth::refresh_ms_auth_token(&client, &msa.data.refresh_token, client_id, scope).await?;
         }
 
         let msa_token = &msa.data.access_token;

--- a/azalea-client/src/account.rs
+++ b/azalea-client/src/account.rs
@@ -93,7 +93,7 @@ impl Account {
         Self::microsoft_with_custom_client_id(email, None).await
     }
 
-    /// Similar to [`account.microsoft()`](Self::microsoft) but you can use your own `client_id` and `scope`.
+    /// Similar to [`account.microsoft()`](Self::microsoft) but you can use your own `client_id`.
     pub async fn microsoft_with_custom_client_id(email: &str, client_id: Option<&'static str>) -> Result<Self, azalea_auth::AuthError> {
         let minecraft_dir = minecraft_folder_path::minecraft_dir().unwrap_or_else(|| {
             panic!(
@@ -135,6 +135,8 @@ impl Account {
     /// let client = reqwest::Client::new();
     ///
     /// let res = azalea_auth::get_ms_link_code(&client, None).await?;
+    /// // Or, `azalea_auth::get_ms_link_code(&client, Some(client_id)).await?`
+    /// // if you want to use your own client_id
     /// println!(
     ///     "Go to {} and enter the code {}",
     ///     res.verification_uri, res.user_code
@@ -150,7 +152,7 @@ impl Account {
         Self::with_microsoft_access_token_and_custom_client_id(msa, None).await
     }
 
-    /// Similar to [`Account::with_microsoft_access_token`] but you can you custom `client_id` and `scope`
+    /// Similar to [`Account::with_microsoft_access_token`] but you can you custom `client_id`.
     pub async fn with_microsoft_access_token_and_custom_client_id(
         mut msa: azalea_auth::cache::ExpiringValue<AccessTokenResponse>,
         client_id: Option<&'static str>

--- a/azalea-client/src/account.rs
+++ b/azalea-client/src/account.rs
@@ -146,13 +146,22 @@ impl Account {
     /// # }
     /// ```
     pub async fn with_microsoft_access_token(
+        msa: azalea_auth::cache::ExpiringValue<AccessTokenResponse>
+    ) -> Result<Self, azalea_auth::AuthError> {
+        Self::with_microsoft_access_token_and_custom_client_id(msa, None, None).await
+    }
+
+    /// Similar to [`Account::with_microsoft_access_token`] but you can you custom `client_id` and `scope`
+    pub async fn with_microsoft_access_token_and_custom_client_id(
         mut msa: azalea_auth::cache::ExpiringValue<AccessTokenResponse>,
+        scope: Option<&'static str>,
+        client_id: Option<&'static str>
     ) -> Result<Self, azalea_auth::AuthError> {
         let client = reqwest::Client::new();
 
         if msa.is_expired() {
             tracing::trace!("refreshing Microsoft auth token");
-            msa = azalea_auth::refresh_ms_auth_token(&client, &msa.data.refresh_token, None, None).await?;
+            msa = azalea_auth::refresh_ms_auth_token(&client, &msa.data.refresh_token, scope, client_id).await?;
         }
 
         let msa_token = &msa.data.access_token;

--- a/azalea-client/src/account.rs
+++ b/azalea-client/src/account.rs
@@ -137,8 +137,8 @@ impl Account {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::Client::new();
     ///
-    /// let res = azalea_auth::get_ms_link_code(&client, "client_id", "scope").await?;
-    /// // Or, `azalea_auth::get_ms_link_code(&client, Some(client_id)).await?`
+    /// let res = azalea_auth::get_ms_link_code(&client, None, None).await?;
+    /// // Or, `azalea_auth::get_ms_link_code(&client, Some(client_id), None).await?`
     /// // if you want to use your own client_id
     /// println!(
     ///     "Go to {} and enter the code {}",

--- a/azalea-client/src/account.rs
+++ b/azalea-client/src/account.rs
@@ -137,14 +137,14 @@ impl Account {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::Client::new();
     ///
-    /// let res = azalea_auth::get_ms_link_code(&client, "00000000441cc96b", "service::user. auth. xboxlive. com::MBI_SSL").await?;
+    /// let res = azalea_auth::get_ms_link_code(&client, "client_id", "scope").await?;
     /// // Or, `azalea_auth::get_ms_link_code(&client, Some(client_id)).await?`
     /// // if you want to use your own client_id
     /// println!(
     ///     "Go to {} and enter the code {}",
     ///     res.verification_uri, res.user_code
     /// );
-    /// let msa = azalea_auth::get_ms_auth_token(&client, res).await?;
+    /// let msa = azalea_auth::get_ms_auth_token(&client, res, "client_id").await?;
     /// Account::with_microsoft_access_token(msa).await?;
     /// # Ok(())
     /// # }

--- a/azalea-client/src/account.rs
+++ b/azalea-client/src/account.rs
@@ -90,11 +90,11 @@ impl Account {
     /// a key for the cache, but it's recommended to use the real email to
     /// avoid confusion.
     pub async fn microsoft(email: &str) -> Result<Self, azalea_auth::AuthError> {
-        Self::microsoft_with_custom_client_id(email, None, None)
+        Self::microsoft_with_custom_client_id(email, None, None).await
     }
 
     /// Similar to [`account.microsoft()`](Self::microsoft) but you can use your own `client_id` and `scope`.
-    pub async fn microsoft_with_custom_client_id(email: &str, scope: Option<&str>, client_id: Option<&str>) -> Result<Self, azalea_auth::AuthError> {
+    pub async fn microsoft_with_custom_client_id(email: &str, scope: Option<&'static str>, client_id: Option<&'static str>) -> Result<Self, azalea_auth::AuthError> {
         let minecraft_dir = minecraft_folder_path::minecraft_dir().unwrap_or_else(|| {
             panic!(
                 "No {} environment variable found",

--- a/azalea-client/src/account.rs
+++ b/azalea-client/src/account.rs
@@ -90,6 +90,11 @@ impl Account {
     /// a key for the cache, but it's recommended to use the real email to
     /// avoid confusion.
     pub async fn microsoft(email: &str) -> Result<Self, azalea_auth::AuthError> {
+        Self::microsoft_with_custom_client_id(email, None, None)
+    }
+
+    /// Similar to [`account.microsoft()`](Self::microsoft) but you can use your own `client_id` and `scope`.
+    pub async fn microsoft_with_custom_client_id(email: &str, scope: Option<&str>, client_id: Option<&str>) -> Result<Self, azalea_auth::AuthError> {
         let minecraft_dir = minecraft_folder_path::minecraft_dir().unwrap_or_else(|| {
             panic!(
                 "No {} environment variable found",
@@ -100,6 +105,8 @@ impl Account {
             email,
             azalea_auth::AuthOpts {
                 cache_file: Some(minecraft_dir.join("azalea-auth.json")),
+                scope,
+                client_id,
                 ..Default::default()
             },
         )
@@ -128,7 +135,7 @@ impl Account {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::Client::new();
     ///
-    /// let res = azalea_auth::get_ms_link_code(&client).await?;
+    /// let res = azalea_auth::get_ms_link_code(&client, None, None).await?;
     /// println!(
     ///     "Go to {} and enter the code {}",
     ///     res.verification_uri, res.user_code
@@ -145,7 +152,7 @@ impl Account {
 
         if msa.is_expired() {
             tracing::trace!("refreshing Microsoft auth token");
-            msa = azalea_auth::refresh_ms_auth_token(&client, &msa.data.refresh_token).await?;
+            msa = azalea_auth::refresh_ms_auth_token(&client, &msa.data.refresh_token, None, None).await?;
         }
 
         let msa_token = &msa.data.access_token;


### PR DESCRIPTION
## What this PR adds?
This PR addresses and closes the issue #130. It introduces two new functions in `azalea_client::Account`:
* `microsoft_with_custom_client_id_and_scope` 
* `with_microsoft_access_token_and_custom_client_id_and_scope`.

This PR will allow the developer, to customize the `client_id` and `scope`, or use the nintendo switch one. Also, some other functions in `auth.rs` like `refresh_ms_auth_token`, `get_ms_link_code`, `interactive_get_ms_auth_token`, etc. are modified and takes some extra parameters now. See the changes in [`auth.rs`](https://github.com/azalea-rs/azalea/pull/159/files#diff-95c725220d95ac22f437570c310f8c41116efd3f4a1876f95cd38455f3bcf63f) for more information.

## Backwards Compatibility?
The existing functions `microsoft` and `with_microsoft_access_token` will maintain their current functionality. However, their implementations have been refactored to depend on the new functions `microsoft_with_custom_client_id_and_scope` and `with_microsoft_access_token_and_custom_client_id_and_scope` to avoid code duplication and facilitate easier maintenance.