### PR TITLE
Upgrade to simdnbt 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "as-any"
@@ -131,12 +131,11 @@ checksum = "5b8a30a44e99a1c83ccb2a6298c563c888952a1c9134953db26876528f84c93a"
 
 [[package]]
 name = "async-channel"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2776ead772134d55b62dd45e59a79e21612d85d0af729b8b7d3967d601a62a"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
- "event-listener",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -144,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
+checksum = "c8828ec6e544c02b0d6691d21ed9f9218d0384a82542855073c2a3f58304aaf0"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -163,7 +162,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -180,7 +179,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -222,7 +221,7 @@ dependencies = [
  "parking_lot",
  "priority-queue",
  "rand",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "thiserror",
  "tokio",
  "tracing",
@@ -266,7 +265,7 @@ version = "0.10.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -299,7 +298,7 @@ version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -431,7 +430,7 @@ version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -510,7 +509,7 @@ version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -529,7 +528,7 @@ version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -547,7 +546,7 @@ dependencies = [
  "nohash-hasher",
  "once_cell",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "serde",
  "serde_json",
  "simdnbt",
@@ -558,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -607,7 +606,7 @@ checksum = "f0e01f8343f391e2d6a63b368b82fb5b252ed43c8713fc87f9a8f2d59407dd00"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -624,7 +623,7 @@ dependencies = [
  "bevy_utils",
  "downcast-rs",
  "fixedbitset",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "thiserror",
  "thread_local",
@@ -639,7 +638,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -666,8 +665,8 @@ checksum = "eb270c98a96243b29465139ed10bda2f675d00a11904f6588a5f7fc4774119c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustc-hash",
- "syn 2.0.63",
+ "rustc-hash 1.1.0",
+ "syn",
  "toml_edit",
 ]
 
@@ -714,7 +713,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
  "uuid",
 ]
 
@@ -773,14 +772,14 @@ checksum = "bef158627f30503d5c18c20c60b444829f698d343516eeaf6eeee078c9a45163"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -799,9 +798,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 
 [[package]]
 name = "byteorder"
@@ -823,9 +822,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 
 [[package]]
 name = "cesu8"
@@ -897,18 +896,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -916,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "colorchoice"
@@ -968,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -1013,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1041,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -1080,15 +1079,15 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1110,9 +1109,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "enum-as-inner"
@@ -1123,7 +1122,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -1167,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.3.0"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1292,7 +1291,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -1350,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glam"
@@ -1420,12 +1419,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "pin-project-lite",
@@ -1433,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "humantime"
@@ -1445,9 +1444,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1464,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http",
@@ -1477,13 +1476,14 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1587,18 +1587,18 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -1624,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru-cache"
@@ -1658,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -1676,9 +1676,9 @@ checksum = "d60a6352e005f1f86008644a9fe336a66f74c94428182162cc69eb8c6fff458d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1819,9 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -1852,9 +1852,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1873,7 +1873,7 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "thread-id",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1918,7 +1918,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -1956,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "plotters"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1969,15 +1969,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
 dependencies = [
  "plotters-backend",
 ]
@@ -1990,9 +1990,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "priority-queue"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509354d8a769e8d0b567d6821b84495c60213162761a732d68ce87c964bd347f"
+checksum = "70c501afe3a2e25c9bd219aa56ec1e04cdb3fcdd763055be268778c13fa82c1f"
 dependencies = [
  "autocfg",
  "equivalent",
@@ -2001,11 +2001,58 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 1.1.0",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash 1.1.0",
+ "rustls",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2069,23 +2116,23 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2099,13 +2146,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2116,15 +2163,15 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64",
  "bytes",
@@ -2143,6 +2190,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -2186,7 +2234,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
+ "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -2236,6 +2284,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,11 +2300,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -2276,9 +2330,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.3"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2314,29 +2368,29 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -2407,8 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "simdnbt"
-version = "0.5.2"
-source = "git+https://github.com/azalea-rs/simdnbt#07bb1e703664eb19328eb58e9a423585b1128687"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7873e74b45488cc8b44a7c0ffc40c156b36402b6001272ab6b301d4e641f185d"
 dependencies = [
  "byteorder",
  "flate2",
@@ -2420,12 +2475,13 @@ dependencies = [
 
 [[package]]
 name = "simdnbt-derive"
-version = "0.5.2"
-source = "git+https://github.com/azalea-rs/simdnbt#07bb1e703664eb19328eb58e9a423585b1128687"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10dbcddd4df92d15834757fb1f61ececc00840b96a2d7b0daf09aef596628c00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -2479,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "socks5-impl"
-version = "0.5.12"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b7cb60ae94f81007e9c4e165b0999415a0b34249805309f31d38767e863329"
+checksum = "922f9d794c286fb5821e900f0cc73cd38d74049508dbe4f17c758b10d387a2bc"
 dependencies = [
  "as-any",
  "async-trait",
@@ -2492,12 +2548,6 @@ dependencies = [
  "thiserror",
  "tokio",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -2517,26 +2567,15 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2545,28 +2584,28 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -2601,9 +2640,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2616,9 +2655,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2635,20 +2674,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
@@ -2670,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 
 [[package]]
 name = "toml_edit"
@@ -2698,7 +2737,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2719,7 +2757,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2733,7 +2770,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
@@ -2888,9 +2925,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna 0.5.0",
@@ -2899,15 +2936,15 @@ dependencies = [
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
  "md-5",
@@ -2982,7 +3019,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3016,7 +3053,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3049,9 +3086,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3102,7 +3139,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3122,18 +3159,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -3144,9 +3181,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3156,9 +3193,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3168,15 +3205,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3186,9 +3223,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3198,9 +3235,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3210,9 +3247,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3222,9 +3259,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -3247,26 +3284,26 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/azalea-auth/Cargo.toml
+++ b/azalea-auth/Cargo.toml
@@ -11,23 +11,23 @@ version = "0.10.1"
 [dependencies]
 azalea-buf = { path = "../azalea-buf", version = "0.10.0" }
 azalea-crypto = { path = "../azalea-crypto", version = "0.10.0" }
-base64 = "0.22.0"
+base64 = "0.22.1"
 chrono = { version = "0.4.38", default-features = false, features = ["serde"] }
 tracing = "0.1.40"
-num-bigint = "0.4.4"
+num-bigint = "0.4.6"
 once_cell = "1.19.0"
-reqwest = { version = "0.12.4", default-features = false, features = [
+reqwest = { version = "0.12.5", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
 rsa = "0.9.6"
-serde = { version = "1.0.198", features = ["derive"] }
-serde_json = "1.0.116"
-thiserror = "1.0.59"
-tokio = { version = "1.37.0", features = ["fs"] }
-uuid = { version = "1.8.0", features = ["serde", "v3"] }
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.120"
+thiserror = "1.0.61"
+tokio = { version = "1.38.0", features = ["fs"] }
+uuid = { version = "1.9.1", features = ["serde", "v3"] }
 md-5 = "0.10.6"
 
 [dev-dependencies]
 env_logger = "0.11.3"
-tokio = { version = "1.37.0", features = ["full"] }
+tokio = { version = "1.38.0", features = ["full"] }

--- a/azalea-block/azalea-block-macros/Cargo.toml
+++ b/azalea-block/azalea-block-macros/Cargo.toml
@@ -12,6 +12,6 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-proc-macro2 = "1.0.81"
+proc-macro2 = "1.0.86"
 quote = "1.0.36"
-syn = "2.0.60"
+syn = "2.0.68"

--- a/azalea-block/azalea-block-macros/src/lib.rs
+++ b/azalea-block/azalea-block-macros/src/lib.rs
@@ -829,7 +829,7 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
 fn name_to_ident(name: &str) -> Ident {
     let ident_str = match name {
         "type" => "kind",
-        _ => &name,
+        _ => name,
     };
     Ident::new(ident_str, proc_macro2::Span::call_site())
 }

--- a/azalea-brigadier/Cargo.toml
+++ b/azalea-brigadier/Cargo.toml
@@ -15,7 +15,7 @@ bevy_ecs = "0.13.0"
 [dependencies]
 azalea-buf = { path = "../azalea-buf", version = "0.10.0", optional = true }
 azalea-chat = { path = "../azalea-chat", version = "0.10.0", optional = true }
-parking_lot = "0.12.1"
+parking_lot = "0.12.3"
 
 [features]
 azalea-buf = ["dep:azalea-buf", "dep:azalea-chat", "azalea-chat/azalea-buf"]

--- a/azalea-buf/Cargo.toml
+++ b/azalea-buf/Cargo.toml
@@ -9,13 +9,13 @@ version = "0.10.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-simdnbt = { version = "0.5", git = "https://github.com/azalea-rs/simdnbt" }
+simdnbt = "0.6"
 azalea-buf-macros = { path = "./azalea-buf-macros", version = "0.10.0" }
 byteorder = "^1.5.0"
 tracing = "0.1.40"
 serde_json = { version = "^1.0", optional = true }
-thiserror = "1.0.59"
-uuid = "^1.8.0"
+thiserror = "1.0.61"
+uuid = "^1.9.1"
 
 [features]
 serde_json = ["dep:serde_json"]

--- a/azalea-buf/azalea-buf-macros/Cargo.toml
+++ b/azalea-buf/azalea-buf-macros/Cargo.toml
@@ -11,6 +11,6 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-proc-macro2 = "^1.0.81"
+proc-macro2 = "^1.0.86"
 quote = "^1.0.36"
-syn = { version = "^2.0.60", features = ["extra-traits"] }
+syn = { version = "^2.0.68", features = ["extra-traits"] }

--- a/azalea-buf/src/read.rs
+++ b/azalea-buf/src/read.rs
@@ -344,13 +344,13 @@ impl<T: McBufReadable, const N: usize> McBufReadable for [T; N] {
 
 impl McBufReadable for simdnbt::owned::NbtTag {
     fn read_from(buf: &mut Cursor<&[u8]>) -> Result<Self, BufReadError> {
-        Ok(simdnbt::owned::NbtTag::read(buf)?)
+        Ok(simdnbt::owned::read_tag(buf)?)
     }
 }
 
 impl McBufReadable for simdnbt::owned::NbtCompound {
     fn read_from(buf: &mut Cursor<&[u8]>) -> Result<Self, BufReadError> {
-        match simdnbt::owned::NbtTag::read(buf)? {
+        match simdnbt::owned::read_tag(buf)? {
             simdnbt::owned::NbtTag::Compound(compound) => Ok(compound),
             _ => Err(BufReadError::Custom("Expected compound tag".to_string())),
         }

--- a/azalea-chat/Cargo.toml
+++ b/azalea-chat/Cargo.toml
@@ -19,9 +19,9 @@ azalea-buf = { path = "../azalea-buf", features = [
     "serde_json",
 ], version = "0.10.0", optional = true }
 azalea-language = { path = "../azalea-language", version = "0.10.0" }
-simdnbt = { version = "0.5", optional = true, git = "https://github.com/azalea-rs/simdnbt" }
+simdnbt = { version = "0.6", optional = true }
 tracing = "0.1.40"
 once_cell = "1.19.0"
 serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0.116"
+serde_json = "^1.0.120"
 azalea-registry = { path = "../azalea-registry", version = "0.10.0", optional = true }

--- a/azalea-chat/src/component.rs
+++ b/azalea-chat/src/component.rs
@@ -11,7 +11,7 @@ use serde::{de, Deserialize, Deserializer, Serialize};
 #[cfg(feature = "simdnbt")]
 use simdnbt::{Deserialize as _, FromNbtTag as _, Serialize as _};
 use std::fmt::Display;
-use tracing::{trace, warn};
+use tracing::{debug, trace, warn};
 
 /// A chat component, basically anything you can see in chat.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Hash)]
@@ -291,181 +291,164 @@ impl simdnbt::Serialize for FormattedText {
 
 #[cfg(feature = "simdnbt")]
 impl simdnbt::FromNbtTag for FormattedText {
-    fn from_nbt_tag(tag: &simdnbt::borrow::NbtTag) -> Option<Self> {
-        // we create a component that we might add siblings to
+    fn from_nbt_tag(tag: simdnbt::borrow::NbtTag) -> Option<Self> {
+        // if it's a string, return a text component with that string
+        if let Some(string) = tag.string() {
+            Some(FormattedText::from(string))
+        }
+        // if it's a compound, make it do things with { text } and stuff
+        // simdnbt::borrow::NbtTag::Compound(compound) => {
+        else if let Some(compound) = tag.compound() {
+            FormattedText::from_nbt_compound(compound)
+        }
+        // ok so it's not a compound, if it's a list deserialize every item
+        else if let Some(list) = tag.list() {
+            let mut component;
+            if let Some(compounds) = list.compounds() {
+                component = FormattedText::from_nbt_compound(compounds.first()?)?;
+                for compound in compounds.into_iter().skip(1) {
+                    component.append(FormattedText::from_nbt_compound(compound)?);
+                }
+            } else if let Some(strings) = list.strings() {
+                component = FormattedText::from(*(strings.first()?));
+                for &string in strings.iter().skip(1) {
+                    component.append(FormattedText::from(string));
+                }
+            } else {
+                debug!("couldn't parse {list:?} as FormattedText");
+                return None;
+            }
+            Some(component)
+        } else {
+            Some(FormattedText::Text(TextComponent::new("".to_owned())))
+        }
+    }
+}
+
+#[cfg(feature = "simdnbt")]
+impl FormattedText {
+    pub fn from_nbt_compound(compound: simdnbt::borrow::NbtCompound) -> Option<Self> {
         let mut component: FormattedText;
 
-        match tag {
-            // if it's a string, return a text component with that string
-            simdnbt::borrow::NbtTag::String(string) => {
-                Some(FormattedText::Text(TextComponent::new(string.to_string())))
-            }
-            // if it's a compound, make it do things with { text } and stuff
-            simdnbt::borrow::NbtTag::Compound(compound) => {
-                if let Some(text) = compound.get("text") {
-                    let text = text.string().unwrap_or_default().to_string();
-                    component = FormattedText::Text(TextComponent::new(text));
-                } else if let Some(translate) = compound.get("translate") {
-                    let translate = translate.string()?.into();
-                    if let Some(with) = compound.get("with") {
-                        let mut with_array = Vec::new();
-                        match with.list()? {
-                            simdnbt::borrow::NbtList::Empty => {}
-                            simdnbt::borrow::NbtList::String(with) => {
-                                for item in *with {
-                                    with_array.push(StringOrComponent::String(item.to_string()));
+        if let Some(text) = compound.get("text") {
+            let text = text.string().unwrap_or_default().to_string();
+            component = FormattedText::Text(TextComponent::new(text));
+        } else if let Some(translate) = compound.get("translate") {
+            let translate = translate.string()?.into();
+            if let Some(with) = compound.get("with") {
+                let mut with_array = Vec::new();
+                let with_list = with.list()?;
+                if with_list.empty() {
+                } else if let Some(with) = with_list.strings() {
+                    for item in with {
+                        with_array.push(StringOrComponent::String(item.to_string()));
+                    }
+                } else if let Some(with) = with_list.compounds() {
+                    for item in with {
+                        // if it's a string component with no styling and no siblings,
+                        // just add a string to
+                        // with_array otherwise add the
+                        // component to the array
+                        if let Some(primitive) = item.get("") {
+                            // minecraft does this sometimes, for example
+                            // for the /give system messages
+                            if let Some(b) = primitive.byte() {
+                                // interpreted as boolean
+                                with_array.push(StringOrComponent::String(
+                                    if b != 0 { "true" } else { "false" }.to_string(),
+                                ));
+                            } else if let Some(s) = primitive.short() {
+                                with_array.push(StringOrComponent::String(s.to_string()));
+                            } else if let Some(i) = primitive.int() {
+                                with_array.push(StringOrComponent::String(i.to_string()));
+                            } else if let Some(l) = primitive.long() {
+                                with_array.push(StringOrComponent::String(l.to_string()));
+                            } else if let Some(f) = primitive.float() {
+                                with_array.push(StringOrComponent::String(f.to_string()));
+                            } else if let Some(d) = primitive.double() {
+                                with_array.push(StringOrComponent::String(d.to_string()));
+                            } else if let Some(s) = primitive.string() {
+                                with_array.push(StringOrComponent::String(s.to_string()));
+                            } else {
+                                warn!("couldn't parse {item:?} as FormattedText because it has a disallowed primitive");
+                                with_array.push(StringOrComponent::String("?".to_string()));
+                            }
+                        } else if let Some(c) = FormattedText::from_nbt_compound(item) {
+                            if let FormattedText::Text(text_component) = c {
+                                if text_component.base.siblings.is_empty()
+                                    && text_component.base.style.is_empty()
+                                {
+                                    with_array.push(StringOrComponent::String(text_component.text));
+                                    continue;
                                 }
                             }
-                            simdnbt::borrow::NbtList::Compound(with) => {
-                                for item in *with {
-                                    // if it's a string component with no styling and no siblings,
-                                    // just add a string to
-                                    // with_array otherwise add the
-                                    // component to the array
-                                    if let Some(primitive) = item.get("") {
-                                        // minecraft does this sometimes, for example
-                                        // for the /give system messages
-                                        match primitive {
-                                            simdnbt::borrow::NbtTag::Byte(b) => {
-                                                // interpreted as boolean
-                                                with_array.push(StringOrComponent::String(
-                                                    if *b != 0 { "true" } else { "false" }
-                                                        .to_string(),
-                                                ));
-                                            }
-                                            simdnbt::borrow::NbtTag::Short(s) => {
-                                                with_array
-                                                    .push(StringOrComponent::String(s.to_string()));
-                                            }
-                                            simdnbt::borrow::NbtTag::Int(i) => {
-                                                with_array
-                                                    .push(StringOrComponent::String(i.to_string()));
-                                            }
-                                            simdnbt::borrow::NbtTag::Long(l) => {
-                                                with_array
-                                                    .push(StringOrComponent::String(l.to_string()));
-                                            }
-                                            simdnbt::borrow::NbtTag::Float(f) => {
-                                                with_array
-                                                    .push(StringOrComponent::String(f.to_string()));
-                                            }
-                                            simdnbt::borrow::NbtTag::Double(d) => {
-                                                with_array
-                                                    .push(StringOrComponent::String(d.to_string()));
-                                            }
-                                            simdnbt::borrow::NbtTag::String(s) => {
-                                                with_array
-                                                    .push(StringOrComponent::String(s.to_string()));
-                                            }
-                                            _ => {
-                                                warn!("couldn't parse {item:?} as FormattedText because it has a disallowed primitive");
-                                                with_array.push(StringOrComponent::String(
-                                                    "?".to_string(),
-                                                ));
-                                            }
-                                        }
-                                    } else if let Some(c) = FormattedText::from_nbt_tag(
-                                        &simdnbt::borrow::NbtTag::Compound(item.clone()),
-                                    ) {
-                                        if let FormattedText::Text(text_component) = c {
-                                            if text_component.base.siblings.is_empty()
-                                                && text_component.base.style.is_empty()
-                                            {
-                                                with_array.push(StringOrComponent::String(
-                                                    text_component.text,
-                                                ));
-                                                continue;
-                                            }
-                                        }
-                                        with_array.push(StringOrComponent::FormattedText(
-                                            FormattedText::from_nbt_tag(
-                                                &simdnbt::borrow::NbtTag::Compound(item.clone()),
-                                            )?,
-                                        ));
-                                    } else {
-                                        warn!("couldn't parse {item:?} as FormattedText");
-                                        with_array.push(StringOrComponent::String("?".to_string()));
-                                    }
-                                }
-                            }
-                            _ => {
-                                warn!("couldn't parse {with:?} as FormattedText because it's not a list of compounds");
-                                return None;
-                            }
+                            with_array.push(StringOrComponent::FormattedText(
+                                FormattedText::from_nbt_compound(item)?,
+                            ));
+                        } else {
+                            warn!("couldn't parse {item:?} as FormattedText");
+                            with_array.push(StringOrComponent::String("?".to_string()));
                         }
-                        component = FormattedText::Translatable(TranslatableComponent::new(
-                            translate, with_array,
-                        ));
-                    } else {
-                        // if it doesn't have a "with", just have the with_array be empty
-                        component = FormattedText::Translatable(TranslatableComponent::new(
-                            translate,
-                            Vec::new(),
-                        ));
                     }
-                } else if let Some(score) = compound.compound("score") {
-                    // object = GsonHelper.getAsJsonObject(jsonObject, "score");
-                    if score.get("name").is_none() || score.get("objective").is_none() {
-                        // A score component needs at least a name and an objective
-                        trace!("A score component needs at least a name and an objective");
-                        return None;
-                    }
-                    // TODO, score text components aren't yet supported
-                    return None;
-                } else if compound.get("selector").is_some() {
-                    // selector text components aren't yet supported
-                    trace!("selector text components aren't yet supported");
-                    return None;
-                } else if compound.get("keybind").is_some() {
-                    // keybind text components aren't yet supported
-                    trace!("keybind text components aren't yet supported");
-                    return None;
-                } else if let Some(tag) = compound.get("") {
-                    return FormattedText::from_nbt_tag(tag);
                 } else {
-                    let _nbt = compound.get("nbt")?;
-                    let _separator = FormattedText::parse_separator_nbt(compound)?;
-
-                    let _interpret = match compound.get("interpret") {
-                        Some(v) => v.byte().unwrap_or_default() != 0,
-                        None => false,
-                    };
-                    if let Some(_block) = compound.get("block") {}
-                    trace!("nbt text components aren't yet supported");
+                    warn!("couldn't parse {with:?} as FormattedText because it's not a list of compounds");
                     return None;
                 }
-                if let Some(extra) = compound.get("extra") {
-                    let extra = extra.list()?.as_nbt_tags();
-                    if extra.is_empty() {
-                        // Unexpected empty array of components
-                        return None;
-                    }
-                    for extra_component in extra {
-                        let sibling = FormattedText::from_nbt_tag(&extra_component)?;
-                        component.append(sibling);
-                    }
-                }
-
-                let style = Style::from_compound(compound).ok()?;
-                component.get_base_mut().style = style;
-
-                Some(component)
+                component =
+                    FormattedText::Translatable(TranslatableComponent::new(translate, with_array));
+            } else {
+                // if it doesn't have a "with", just have the with_array be empty
+                component =
+                    FormattedText::Translatable(TranslatableComponent::new(translate, Vec::new()));
             }
-            // ok so it's not a compound, if it's a list deserialize every item
-            simdnbt::borrow::NbtTag::List(list) => {
-                let list = list.compounds()?;
-                let mut component = FormattedText::from_nbt_tag(
-                    &simdnbt::borrow::NbtTag::Compound(list.first()?.clone()),
-                )?;
-                for i in 1..list.len() {
-                    component.append(FormattedText::from_nbt_tag(
-                        &simdnbt::borrow::NbtTag::Compound(list.get(i)?.clone()),
-                    )?);
-                }
-                Some(component)
+        } else if let Some(score) = compound.compound("score") {
+            // object = GsonHelper.getAsJsonObject(jsonObject, "score");
+            if score.get("name").is_none() || score.get("objective").is_none() {
+                // A score component needs at least a name and an objective
+                trace!("A score component needs at least a name and an objective");
+                return None;
             }
-            _ => Some(FormattedText::Text(TextComponent::new("".to_owned()))),
+            // TODO, score text components aren't yet supported
+            return None;
+        } else if compound.get("selector").is_some() {
+            // selector text components aren't yet supported
+            trace!("selector text components aren't yet supported");
+            return None;
+        } else if compound.get("keybind").is_some() {
+            // keybind text components aren't yet supported
+            trace!("keybind text components aren't yet supported");
+            return None;
+        } else if let Some(tag) = compound.get("") {
+            return FormattedText::from_nbt_tag(tag);
+        } else {
+            let _nbt = compound.get("nbt")?;
+            let _separator = FormattedText::parse_separator_nbt(&compound)?;
+
+            let _interpret = match compound.get("interpret") {
+                Some(v) => v.byte().unwrap_or_default() != 0,
+                None => false,
+            };
+            if let Some(_block) = compound.get("block") {}
+            trace!("nbt text components aren't yet supported");
+            return None;
         }
+        if let Some(extra) = compound.get("extra") {
+            for c in FormattedText::from_nbt_tag(extra)? {
+                component.append(c);
+            }
+        }
+
+        let style = Style::from_compound(compound).ok()?;
+        component.get_base_mut().style = style;
+
+        Some(component)
+    }
+}
+
+#[cfg(feature = "simdnbt")]
+impl From<&simdnbt::Mutf8Str> for FormattedText {
+    fn from(s: &simdnbt::Mutf8Str) -> Self {
+        FormattedText::Text(TextComponent::new(s.to_string()))
     }
 }
 
@@ -475,7 +458,7 @@ impl McBufReadable for FormattedText {
     fn read_from(buf: &mut std::io::Cursor<&[u8]>) -> Result<Self, BufReadError> {
         let nbt = simdnbt::borrow::read_optional_tag(buf)?;
         if let Some(nbt) = nbt {
-            FormattedText::from_nbt_tag(&nbt).ok_or(BufReadError::Custom(
+            FormattedText::from_nbt_tag(nbt.as_tag()).ok_or(BufReadError::Custom(
                 "couldn't convert nbt to chat message".to_owned(),
             ))
         } else {

--- a/azalea-chat/src/style.rs
+++ b/azalea-chat/src/style.rs
@@ -581,7 +581,7 @@ impl Style {
 #[cfg(feature = "simdnbt")]
 impl simdnbt::Deserialize for Style {
     fn from_compound(
-        compound: &simdnbt::borrow::NbtCompound,
+        compound: simdnbt::borrow::NbtCompound,
     ) -> Result<Self, simdnbt::DeserializeError> {
         let bold = compound.byte("bold").map(|v| v != 0);
         let italic = compound.byte("italic").map(|v| v != 0);

--- a/azalea-client/Cargo.toml
+++ b/azalea-client/Cargo.toml
@@ -9,9 +9,9 @@ version = "0.10.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-simdnbt = { version = "0.5", git = "https://github.com/azalea-rs/simdnbt" }
-reqwest = { version = "0.12.4", default-features = false }
-anyhow = "1.0.82"
+simdnbt = "0.6"
+reqwest = { version = "0.12.5", default-features = false }
+anyhow = "1.0.86"
 async-trait = "0.1.80"
 azalea-auth = { path = "../azalea-auth", version = "0.10.0" }
 azalea-block = { path = "../azalea-block", version = "0.10.0" }
@@ -23,23 +23,23 @@ azalea-buf = { path = "../azalea-buf", version = "0.10.0" }
 azalea-protocol = { path = "../azalea-protocol", version = "0.10.0" }
 azalea-registry = { path = "../azalea-registry", version = "0.10.0" }
 azalea-world = { path = "../azalea-world", version = "0.10.0" }
-bevy_app = "0.13.2"
-bevy_ecs = "0.13.2"
-bevy_log = { version = "0.13.2", optional = true }
-bevy_tasks = "0.13.2"
-bevy_time = "0.13.2"
-derive_more = { version = "0.99.17", features = ["deref", "deref_mut"] }
+bevy_app = "0.13.0"
+bevy_ecs = "0.13.0"
+bevy_log = { version = "0.13.0", optional = true }
+bevy_tasks = "0.13.0"
+bevy_time = "0.13.0"
+derive_more = { version = "0.99.18", features = ["deref", "deref_mut"] }
 futures = "0.3.30"
 tracing = "0.1.40"
 nohash-hasher = "0.2.0"
 once_cell = "1.19.0"
-parking_lot = { version = "^0.12.1", features = ["deadlock_detection"] }
-regex = "1.10.4"
-thiserror = "^1.0.59"
-tokio = { version = "^1.37.0", features = ["sync"] }
-uuid = "^1.8.0"
-serde_json = "1.0.116"
-serde = "1.0.198"
+parking_lot = { version = "^0.12.3", features = ["deadlock_detection"] }
+regex = "1.10.5"
+thiserror = "^1.0.61"
+tokio = { version = "^1.38.0", features = ["sync"] }
+uuid = "^1.9.1"
+serde_json = "1.0.120"
+serde = "1.0.203"
 minecraft_folder_path = "0.1.2"
 azalea-entity = { version = "0.10.0", path = "../azalea-entity" }
 azalea-inventory = { version = "0.10.0", path = "../azalea-inventory" }

--- a/azalea-core/Cargo.toml
+++ b/azalea-core/Cargo.toml
@@ -9,15 +9,15 @@ version = "0.10.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-simdnbt = { version = "0.5", git = "https://github.com/azalea-rs/simdnbt" }
+simdnbt = "0.6"
 azalea-buf = { path = "../azalea-buf", version = "0.10.0" }
 azalea-registry = { path = "../azalea-registry", version = "0.10.0" }
-bevy_ecs = { version = "0.13.2", default-features = false, optional = true }
+bevy_ecs = { version = "0.13.0", default-features = false, optional = true }
 nohash-hasher = "0.2.0"
-num-traits = "0.2.18"
+num-traits = "0.2.19"
 serde = { version = "^1.0", optional = true }
-uuid = "^1.8.0"
-serde_json = "^1.0.116"
+uuid = "^1.9.1"
+serde_json = "^1.0.120"
 tracing = "0.1.40"
 
 [features]

--- a/azalea-core/src/lib.rs
+++ b/azalea-core/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![feature(lazy_cell)]
 #![feature(trait_upcasting)]
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]

--- a/azalea-core/src/registry_holder.rs
+++ b/azalea-core/src/registry_holder.rs
@@ -53,7 +53,7 @@ impl RegistryHolder {
             value.write(&mut nbt_bytes);
             let nbt_borrow_compound =
                 simdnbt::borrow::read_compound(&mut Cursor::new(&nbt_bytes)).ok()?;
-            let value = match T::from_compound(&nbt_borrow_compound) {
+            let value = match T::from_compound((&nbt_borrow_compound).into()) {
                 Ok(value) => value,
                 Err(err) => {
                     return Some(Err(err));
@@ -182,7 +182,7 @@ pub enum MonsterSpawnLightLevel {
 }
 
 impl FromNbtTag for MonsterSpawnLightLevel {
-    fn from_nbt_tag(tag: &simdnbt::borrow::NbtTag) -> Option<Self> {
+    fn from_nbt_tag(tag: simdnbt::borrow::NbtTag) -> Option<Self> {
         if let Some(value) = tag.int() {
             Some(Self::Simple(value as u32))
         } else if let Some(value) = tag.compound() {
@@ -240,7 +240,7 @@ pub enum BiomePrecipitation {
     Snow,
 }
 impl FromNbtTag for BiomePrecipitation {
-    fn from_nbt_tag(tag: &simdnbt::borrow::NbtTag) -> Option<Self> {
+    fn from_nbt_tag(tag: simdnbt::borrow::NbtTag) -> Option<Self> {
         match tag.string()?.to_str().as_ref() {
             "none" => Some(Self::None),
             "rain" => Some(Self::Rain),

--- a/azalea-core/src/resource_location.rs
+++ b/azalea-core/src/resource_location.rs
@@ -101,7 +101,7 @@ impl<'de> Deserialize<'de> for ResourceLocation {
 }
 
 impl FromNbtTag for ResourceLocation {
-    fn from_nbt_tag(tag: &simdnbt::borrow::NbtTag) -> Option<Self> {
+    fn from_nbt_tag(tag: simdnbt::borrow::NbtTag) -> Option<Self> {
         tag.string().and_then(|s| s.to_str().parse().ok())
     }
 }

--- a/azalea-crypto/Cargo.toml
+++ b/azalea-crypto/Cargo.toml
@@ -12,13 +12,13 @@ repository = "https://github.com/azalea-rs/azalea/tree/main/azalea-crypto"
 aes = "0.8.4"
 azalea-buf = { path = "../azalea-buf", version = "0.10.0" }
 cfb8 = "0.8.1"
-num-bigint = "^0.4.4"
+num-bigint = "^0.4.6"
 rand = { version = "^0.8.5", features = ["getrandom"] }
 rsa = { version = "0.9.6", features = ["sha2"] }
 rsa_public_encrypt_pkcs1 = "0.4.0"
 sha-1 = "^0.10.1"
 sha2 = "0.10.8"
-uuid = "^1.8.0"
+uuid = "^1.9.1"
 
 [dev-dependencies]
 criterion = { version = "^0.5.1", features = ["html_reports"] }

--- a/azalea-entity/Cargo.toml
+++ b/azalea-entity/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-simdnbt = { version = "0.5", git = "https://github.com/azalea-rs/simdnbt" }
+simdnbt = "0.6"
 azalea-block = { version = "0.10.0", path = "../azalea-block" }
 azalea-buf = { version = "0.10.0", path = "../azalea-buf" }
 azalea-chat = { version = "0.10.0", path = "../azalea-chat", features = [
@@ -19,12 +19,12 @@ azalea-core = { version = "0.10.0", path = "../azalea-core" }
 azalea-inventory = { version = "0.10.0", path = "../azalea-inventory" }
 azalea-registry = { version = "0.10.0", path = "../azalea-registry" }
 azalea-world = { version = "0.10.0", path = "../azalea-world" }
-bevy_app = "0.13.2"
-bevy_ecs = "0.13.2"
-derive_more = "0.99.17"
+bevy_app = "0.13.0"
+bevy_ecs = "0.13.0"
+derive_more = "0.99.18"
 enum-as-inner = "0.6.0"
 tracing = "0.1.40"
 nohash-hasher = "0.2.0"
-parking_lot = "0.12.1"
-thiserror = "1.0.59"
-uuid = "1.8.0"
+parking_lot = "0.12.3"
+thiserror = "1.0.61"
+uuid = "1.9.1"

--- a/azalea-inventory/Cargo.toml
+++ b/azalea-inventory/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.10.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-simdnbt = { version = "0.5", git = "https://github.com/azalea-rs/simdnbt" }
+simdnbt = "0.6"
 azalea-buf = { version = "0.10.0", path = "../azalea-buf" }
 azalea-inventory-macros = { version = "0.10.0", path = "./azalea-inventory-macros" }
 azalea-registry = { version = "0.10.0", path = "../azalea-registry" }
@@ -17,4 +17,4 @@ azalea-chat = { version = "0.10.0", path = "../azalea-chat", features = [
     "azalea-buf",
 ] }
 azalea-core = { version = "0.10.0", path = "../azalea-core" }
-uuid = "1.8.0"
+uuid = "1.9.1"

--- a/azalea-inventory/azalea-inventory-macros/Cargo.toml
+++ b/azalea-inventory/azalea-inventory-macros/Cargo.toml
@@ -12,6 +12,6 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-proc-macro2 = "1.0.81"
+proc-macro2 = "1.0.86"
 quote = "1.0.36"
-syn = "2.0.60"
+syn = "2.0.68"

--- a/azalea-language/Cargo.toml
+++ b/azalea-language/Cargo.toml
@@ -11,5 +11,5 @@ version = "0.10.0"
 [dependencies]
 once_cell = "1.19.0"
 serde = "^1.0"
-serde_json = "^1.0.116"
+serde_json = "^1.0.120"
 # tokio = {version = "^1.21.2", features = ["fs"]}

--- a/azalea-physics/Cargo.toml
+++ b/azalea-physics/Cargo.toml
@@ -13,16 +13,16 @@ azalea-block = { path = "../azalea-block", version = "0.10.0" }
 azalea-core = { path = "../azalea-core", version = "0.10.0" }
 azalea-registry = { path = "../azalea-registry", version = "0.10.0" }
 azalea-world = { path = "../azalea-world", version = "0.10.0" }
-bevy_app = "0.13.2"
-bevy_ecs = "0.13.2"
+bevy_app = "0.13.0"
+bevy_ecs = "0.13.0"
 tracing = "0.1.40"
 once_cell = "1.19.0"
-parking_lot = "^0.12.1"
+parking_lot = "^0.12.3"
 nohash-hasher = "0.2.0"
 smallvec = "1.13.2"
 azalea-entity = { version = "0.10.0", path = "../azalea-entity" }
 azalea-inventory = { version = "0.10.0", path = "../azalea-inventory" }
 
 [dev-dependencies]
-bevy_time = "0.13.2"
-uuid = "^1.8.0"
+bevy_time = "0.13.0"
+uuid = "^1.9.1"

--- a/azalea-physics/src/lib.rs
+++ b/azalea-physics/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![feature(trait_alias)]
-#![feature(lazy_cell)]
 
 pub mod clip;
 pub mod collision;

--- a/azalea-protocol/Cargo.toml
+++ b/azalea-protocol/Cargo.toml
@@ -9,8 +9,8 @@ version = "0.10.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-simdnbt = { version = "0.5", git = "https://github.com/azalea-rs/simdnbt" }
-async-recursion = "1.1.0"
+simdnbt = "0.6"
+async-recursion = "1.1.1"
 azalea-auth = { path = "../azalea-auth", version = "0.10.0" }
 azalea-block = { path = "../azalea-block", default-features = false, version = "0.10.0" }
 azalea-brigadier = { path = "../azalea-brigadier", version = "0.10.0", features = [
@@ -28,27 +28,27 @@ azalea-crypto = { path = "../azalea-crypto", version = "0.10.0" }
 azalea-protocol-macros = { path = "./azalea-protocol-macros", version = "0.10.0" }
 azalea-registry = { path = "../azalea-registry", version = "0.10.0" }
 azalea-world = { path = "../azalea-world", version = "0.10.0" }
-bevy_ecs = { version = "0.13.2", default-features = false }
+bevy_ecs = { version = "0.13.0", default-features = false }
 byteorder = "^1.5.0"
 bytes = "^1.6.0"
-flate2 = "1.0.28"
+flate2 = "1.0.30"
 futures = "0.3.30"
 futures-lite = "2.3.0"
 futures-util = "0.3.30"
 tracing = "0.1.40"
 serde = { version = "^1.0", features = ["serde_derive"] }
-serde_json = "^1.0.116"
-thiserror = "1.0.59"
-tokio = { version = "^1.37.0", features = ["io-util", "net", "macros"] }
-tokio-util = { version = "0.7.10", features = ["codec"] }
+serde_json = "^1.0.120"
+thiserror = "1.0.61"
+tokio = { version = "^1.38.0", features = ["io-util", "net", "macros"] }
+tokio-util = { version = "0.7.11", features = ["codec"] }
 trust-dns-resolver = { version = "^0.23.2", default-features = false, features = [
     "tokio-runtime",
 ] }
-uuid = "1.8.0"
-log = "0.4.21"
+uuid = "1.9.1"
+log = "0.4.22"
 azalea-entity = { version = "0.10.0", path = "../azalea-entity" }
 azalea-inventory = { version = "0.10.0", path = "../azalea-inventory" }
-socks5-impl = "0.5.12"
+socks5-impl = "0.5.14"
 
 [features]
 connecting = []
@@ -56,7 +56,7 @@ default = ["packets"]
 packets = ["connecting", "dep:azalea-core"]
 
 [dev-dependencies]
-anyhow = "^1.0.82"
+anyhow = "^1.0.86"
 tracing = "^0.1.40"
 tracing-subscriber = "^0.3.18"
 once_cell = "1.19.0"

--- a/azalea-protocol/azalea-protocol-macros/Cargo.toml
+++ b/azalea-protocol/azalea-protocol-macros/Cargo.toml
@@ -11,6 +11,6 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-proc-macro2 = "^1.0.81"
+proc-macro2 = "^1.0.86"
 quote = "^1.0.36"
-syn = "^2.0.60"
+syn = "^2.0.68"

--- a/azalea-registry/Cargo.toml
+++ b/azalea-registry/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.10.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-simdnbt = { version = "0.5", git = "https://github.com/azalea-rs/simdnbt" }
+simdnbt = "0.6"
 azalea-buf = { path = "../azalea-buf", version = "0.10.0" }
 azalea-registry-macros = { path = "./azalea-registry-macros", version = "0.10.0" }
 once_cell = "1.19.0"

--- a/azalea-registry/azalea-registry-macros/Cargo.toml
+++ b/azalea-registry/azalea-registry-macros/Cargo.toml
@@ -12,9 +12,9 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-proc-macro2 = "1.0.81"
+proc-macro2 = "1.0.86"
 quote = "1.0.36"
-syn = "2.0.60"
+syn = "2.0.68"
 
 [features]
 serde = []

--- a/azalea-world/Cargo.toml
+++ b/azalea-world/Cargo.toml
@@ -9,24 +9,24 @@ version = "0.10.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-simdnbt = { version = "0.5", git = "https://github.com/azalea-rs/simdnbt" }
+simdnbt = "0.6"
 azalea-block = { path = "../azalea-block", default-features = false, version = "0.10.0" }
 azalea-buf = { path = "../azalea-buf", version = "0.10.0" }
 azalea-core = { path = "../azalea-core", version = "0.10.0", features = [
 	"bevy_ecs",
 ] }
 azalea-registry = { path = "../azalea-registry", version = "0.10.0" }
-bevy_ecs = "0.13.2"
-derive_more = { version = "0.99.17", features = ["deref", "deref_mut"] }
+bevy_ecs = "0.13.0"
+derive_more = { version = "0.99.18", features = ["deref", "deref_mut"] }
 tracing = "0.1.40"
 nohash-hasher = "0.2.0"
 once_cell = "1.19.0"
-parking_lot = "^0.12.1"
-thiserror = "1.0.59"
-uuid = "1.8.0"
-serde_json = "1.0.116"
-serde = "1.0.198"
-rustc-hash = "1.1.0"
+parking_lot = "^0.12.3"
+thiserror = "1.0.61"
+uuid = "1.9.1"
+serde_json = "1.0.120"
+serde = "1.0.203"
+rustc-hash = "2.0.0"
 
 [dev-dependencies]
 azalea-client = { path = "../azalea-client" }

--- a/azalea/Cargo.toml
+++ b/azalea/Cargo.toml
@@ -12,7 +12,7 @@ pre-release-replacements = [
 ]
 
 [dependencies]
-anyhow = "^1.0.82"
+anyhow = "^1.0.86"
 async-trait = "0.1.80"
 azalea-block = { version = "0.10.0", path = "../azalea-block" }
 azalea-chat = { version = "0.10.0", path = "../azalea-chat" }
@@ -25,23 +25,23 @@ azalea-world = { version = "0.10.0", path = "../azalea-world" }
 azalea-auth = { version = "0.10.0", path = "../azalea-auth" }
 azalea-brigadier = { version = "0.10.0", path = "../azalea-brigadier" }
 azalea-buf = { version = "0.10.0", path = "../azalea-buf" }
-bevy_app = "0.13.2"
-bevy_ecs = "0.13.2"
-bevy_tasks = { version = "0.13.2", features = ["multi-threaded"] }
-derive_more = { version = "0.99.17", features = ["deref", "deref_mut"] }
+bevy_app = "0.13.0"
+bevy_ecs = "0.13.0"
+bevy_tasks = { version = "0.13.0", features = ["multi-threaded"] }
+derive_more = { version = "0.99.18", features = ["deref", "deref_mut"] }
 futures = "0.3.30"
 futures-lite = "2.3.0"
 tracing = "0.1.40"
 nohash-hasher = "0.2.0"
-num-traits = "0.2.18"
-parking_lot = { version = "^0.12.1", features = ["deadlock_detection"] }
-priority-queue = "2.0.2"
-thiserror = "^1.0.59"
-tokio = "^1.37.0"
-uuid = "1.8.0"
-bevy_log = "0.13.2"
-bevy_time = "0.13.2"
-rustc-hash = "1.1.0"
+num-traits = "0.2.19"
+parking_lot = { version = "^0.12.3", features = ["deadlock_detection"] }
+priority-queue = "2.0.3"
+thiserror = "^1.0.61"
+tokio = "^1.38.0"
+uuid = "1.9.1"
+bevy_log = "0.13.0"
+bevy_time = "0.13.0"
+rustc-hash = "2.0.0"
 azalea-inventory = { version = "0.10.0", path = "../azalea-inventory" }
 azalea-entity = { version = "0.10.0", path = "../azalea-entity" }
 

--- a/azalea/src/lib.rs
+++ b/azalea/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![allow(incomplete_features)]
 #![feature(type_changing_struct_update)]
-#![feature(lazy_cell)]
 #![feature(let_chains)]
 #![feature(never_type)]
 


### PR DESCRIPTION
simdnbt 0.6 rewrites `borrow` to optimize how tags are represented in memory, and fixes a memory safety issue.

Also I upgraded other deps except Bevy since that's gonna need to be a separate change.
