### PR TITLE
Determine rust channel by parsing rustc output if env vars do not exist

### DIFF
--- a/azalea/build.rs
+++ b/azalea/build.rs
@@ -1,7 +1,11 @@
+use std::env;
 use std::process::Command;
 
 fn main() {
-    let rustc_version_output = Command::new("rustc").arg("-V").output().unwrap();
+    let rustc_command = env::var("RUSTC")
+        .or_else(|_| env::var("CARGO_BUILD_RUSTC"))
+        .unwrap_or(String::from("rustc"));
+    let rustc_version_output = Command::new(rustc_command).arg("-V").output().unwrap();
     if !rustc_version_output.status.success()
         || !String::from_utf8(rustc_version_output.stdout)
             .unwrap()

--- a/azalea/build.rs
+++ b/azalea/build.rs
@@ -2,15 +2,23 @@ use std::env;
 use std::process::Command;
 
 fn main() {
-    let rustc_command = env::var("RUSTC")
-        .or_else(|_| env::var("CARGO_BUILD_RUSTC"))
-        .unwrap_or(String::from("rustc"));
-    let rustc_version_output = Command::new(rustc_command).arg("-V").output().unwrap();
-    if !rustc_version_output.status.success()
-        || !String::from_utf8(rustc_version_output.stdout)
-            .unwrap()
-            .contains("nightly")
-    {
-        panic!("Azalea currently requires nightly Rust. If you have installed Rust with rustup you can use `rustup override set nightly` to set the toolchain for this directory.");
+    match env::var("RUSTUP_TOOLCHAIN") {
+        Ok(rust_toolchain) if !rust_toolchain.starts_with("nightly")  => { // stable & beta
+            panic!("Azalea currently requires nightly Rust. You can use `rustup override set nightly` to set the toolchain for this directory.");
+        }
+        Ok(_) => return, // nightly
+        Err(_) => { // probably not installed via rustup, run rustc and parse its output
+            let rustc_command = env::var("RUSTC")
+                .or_else(|_| env::var("CARGO_BUILD_RUSTC"))
+                .unwrap_or(String::from("rustc"));
+            let rustc_version_output = Command::new(rustc_command).arg("-V").output().unwrap();
+            if !rustc_version_output.status.success()
+                || !String::from_utf8(rustc_version_output.stdout)
+                    .unwrap()
+                    .contains("nightly")
+            {
+                panic!("Azalea currently requires nightly Rust. It seems that you did not install Rust via rustup. Please check the documentation for your installation method, to find out how to use nightly Rust.");
+            }
+        }
     }
 }

--- a/azalea/build.rs
+++ b/azalea/build.rs
@@ -1,8 +1,12 @@
-use std::env;
+use std::process::Command;
 
 fn main() {
-    let rust_toolchain = env::var("RUSTUP_TOOLCHAIN").unwrap();
-    if rust_toolchain.starts_with("stable") {
-        panic!("Azalea currently requires nightly Rust. You can use `rustup override set nightly` to set the toolchain for this directory.");
+    let rustc_version_output = Command::new("rustc").arg("-V").output().unwrap();
+    if !rustc_version_output.status.success()
+        || !String::from_utf8(rustc_version_output.stdout)
+            .unwrap()
+            .contains("nightly")
+    {
+        panic!("Azalea currently requires nightly Rust. If you have installed Rust with rustup you can use `rustup override set nightly` to set the toolchain for this directory.");
     }
 }


### PR DESCRIPTION
The RUSTUP_TOOLCHAIN environment variable might not always be present. This is the case for e.g. NixOS where rust is routinely not installed via rustup, thus not setting this env var, causing build failures. Instead, build.rs will now run `rustc -V` and check if the output contains the word "nightly".