### PR TITLE
Added Left Click Mine (1.21)

### DIFF
--- a/azalea-client/src/mining.rs
+++ b/azalea-client/src/mining.rs
@@ -1,6 +1,6 @@
 use azalea_block::{Block, BlockState, FluidState};
 use azalea_core::{direction::Direction, game_type::GameMode, position::BlockPos, tick::GameTick};
-use azalea_entity::{mining::get_mine_progress, FluidOnEyes, Physics, Position};
+use azalea_entity::{mining::get_mine_progress, FluidOnEyes, Physics};
 use azalea_inventory::ItemSlot;
 use azalea_physics::PhysicsSet;
 use azalea_protocol::packets::game::serverbound_player_action_packet::{
@@ -10,7 +10,7 @@ use azalea_world::{InstanceContainer, InstanceName};
 use bevy_app::{App, Plugin, Update};
 use bevy_ecs::prelude::*;
 use derive_more::{Deref, DerefMut};
-use tracing::info;
+use tracing::debug;
 
 use crate::{
     interact::{
@@ -97,7 +97,6 @@ fn handle_auto_mine(
     mut query: Query<
         (
             &HitResultComponent,
-            &Position,
             Entity,
             Option<&Mining>,
             &InventoryComponent,
@@ -110,7 +109,6 @@ fn handle_auto_mine(
 ) {
     for (
         hit_result_component,
-        position,
         entity,
         mining,
         inventory,
@@ -120,16 +118,15 @@ fn handle_auto_mine(
     {
         let block_pos = hit_result_component.block_pos;
 
-        if (mining.is_none()
+        if mining.is_none()
             || !is_same_mining_target(
                 block_pos,
                 inventory,
                 current_mining_pos,
                 current_mining_item,
-            ))
-            && position.distance_to(&block_pos.to_vec3_floored()) <= 7.0
+            )
         {
-            info!("sending mining event");
+            debug!("sending mining event");
             start_mining_block_event_writer.send(StartMiningBlockEvent {
                 entity,
                 position: block_pos,


### PR DESCRIPTION
This PR is similar to #156 but instead this is on main branch.

## What this PR does?
This PR, will introduce a function in `azalea::Client` i.e. `left_click_mine`, once it is enabled it will make the bot mine the blocks it is looking at if it is within it's range In simpler words, it is a simple left-click implementation for mining blocks.

## Why this was added?
Although, it is quite basic functionality which could be used either for digging tunnels, mining stones in stone generator, etc. But I thought having it out of the box supported by azalea would be great, that's why I opened this PR.