### PR TITLE
Derive Deserialize & Serialize for BlockPos & Vec3

### DIFF
--- a/azalea-core/src/position.rs
+++ b/azalea-core/src/position.rs
@@ -4,6 +4,8 @@
 //! for entity positions and block positions, respectively.
 
 use azalea_buf::{BufReadError, McBuf, McBufReadable, McBufWritable};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::{
     fmt,
     hash::Hash,
@@ -211,6 +213,7 @@ macro_rules! vec3_impl {
 /// Used to represent an exact position in the world where an entity could be.
 /// For blocks, [`BlockPos`] is used instead.
 #[derive(Clone, Copy, Debug, Default, PartialEq, McBuf)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Vec3 {
     pub x: f64,
     pub y: f64,
@@ -235,6 +238,7 @@ impl Vec3 {
 /// The coordinates of a block in the world. For entities (if the coordinate
 /// with decimals), use [`Vec3`] instead.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct BlockPos {
     pub x: i32,
     pub y: i32,


### PR DESCRIPTION
This allows you to `Deserialize` and `Serialize` `BlockPos` and `Vec` with the `serde` feature flag.