### PR TITLE
Add missing yaw and patch fields to ServerboundUseItemPacket

### DIFF
--- a/azalea-protocol/src/packets/game/serverbound_use_item_packet.rs
+++ b/azalea-protocol/src/packets/game/serverbound_use_item_packet.rs
@@ -7,4 +7,6 @@ pub struct ServerboundUseItemPacket {
     pub hand: InteractionHand,
     #[var]
     pub sequence: u32,
+    pub yaw: f32,
+    pub pitch: f32,
 }


### PR DESCRIPTION
ServerboundUseItemPacket fails to decode because it's missing the yaw and pitch fields that were added in 1.20 or 1.21