### PR TITLE
Make some internal system handles public for use with before/after

### DIFF
--- a/azalea-client/src/chat.rs
+++ b/azalea-client/src/chat.rs
@@ -207,7 +207,7 @@ pub struct SendChatEvent {
     pub content: String,
 }
 
-fn handle_send_chat_event(
+pub fn handle_send_chat_event(
     mut events: EventReader<SendChatEvent>,
     mut send_chat_kind_events: EventWriter<SendChatKindEvent>,
 ) {
@@ -250,7 +250,7 @@ pub enum ChatPacketKind {
     Command,
 }
 
-fn handle_send_chat_kind_event(
+pub fn handle_send_chat_kind_event(
     mut events: EventReader<SendChatKindEvent>,
     mut send_packet_events: EventWriter<SendPacketEvent>,
 ) {

--- a/azalea-client/src/chunks.rs
+++ b/azalea-client/src/chunks.rs
@@ -71,7 +71,7 @@ pub struct ChunkBatchFinishedEvent {
     pub batch_size: u32,
 }
 
-fn handle_receive_chunk_events(
+pub fn handle_receive_chunk_events(
     mut events: EventReader<ReceiveChunkEvent>,
     mut query: Query<&mut InstanceHolder>,
 ) {

--- a/azalea-client/src/events.rs
+++ b/azalea-client/src/events.rs
@@ -134,20 +134,20 @@ impl Plugin for EventPlugin {
 }
 
 // when LocalPlayerEvents is added, it means the client just started
-fn init_listener(query: Query<&LocalPlayerEvents, Added<LocalPlayerEvents>>) {
+pub fn init_listener(query: Query<&LocalPlayerEvents, Added<LocalPlayerEvents>>) {
     for local_player_events in &query {
         let _ = local_player_events.send(Event::Init);
     }
 }
 
 // when MinecraftEntityId is added, it means the player is now in the world
-fn login_listener(query: Query<&LocalPlayerEvents, Added<MinecraftEntityId>>) {
+pub fn login_listener(query: Query<&LocalPlayerEvents, Added<MinecraftEntityId>>) {
     for local_player_events in &query {
         let _ = local_player_events.send(Event::Login);
     }
 }
 
-fn chat_listener(query: Query<&LocalPlayerEvents>, mut events: EventReader<ChatReceivedEvent>) {
+pub fn chat_listener(query: Query<&LocalPlayerEvents>, mut events: EventReader<ChatReceivedEvent>) {
     for event in events.read() {
         let local_player_events = query
             .get(event.entity)
@@ -157,13 +157,13 @@ fn chat_listener(query: Query<&LocalPlayerEvents>, mut events: EventReader<ChatR
 }
 
 // only tick if we're in a world
-fn tick_listener(query: Query<&LocalPlayerEvents, With<InstanceName>>) {
+pub fn tick_listener(query: Query<&LocalPlayerEvents, With<InstanceName>>) {
     for local_player_events in &query {
         let _ = local_player_events.send(Event::Tick);
     }
 }
 
-fn packet_listener(query: Query<&LocalPlayerEvents>, mut events: EventReader<PacketEvent>) {
+pub fn packet_listener(query: Query<&LocalPlayerEvents>, mut events: EventReader<PacketEvent>) {
     for event in events.read() {
         let local_player_events = query
             .get(event.entity)
@@ -172,7 +172,10 @@ fn packet_listener(query: Query<&LocalPlayerEvents>, mut events: EventReader<Pac
     }
 }
 
-fn add_player_listener(query: Query<&LocalPlayerEvents>, mut events: EventReader<AddPlayerEvent>) {
+pub fn add_player_listener(
+    query: Query<&LocalPlayerEvents>,
+    mut events: EventReader<AddPlayerEvent>,
+) {
     for event in events.read() {
         let local_player_events = query
             .get(event.entity)
@@ -181,7 +184,7 @@ fn add_player_listener(query: Query<&LocalPlayerEvents>, mut events: EventReader
     }
 }
 
-fn update_player_listener(
+pub fn update_player_listener(
     query: Query<&LocalPlayerEvents>,
     mut events: EventReader<UpdatePlayerEvent>,
 ) {
@@ -193,7 +196,7 @@ fn update_player_listener(
     }
 }
 
-fn remove_player_listener(
+pub fn remove_player_listener(
     query: Query<&LocalPlayerEvents>,
     mut events: EventReader<RemovePlayerEvent>,
 ) {
@@ -213,7 +216,10 @@ pub fn death_listener(query: Query<&LocalPlayerEvents>, mut events: EventReader<
     }
 }
 
-fn keepalive_listener(query: Query<&LocalPlayerEvents>, mut events: EventReader<KeepAliveEvent>) {
+pub fn keepalive_listener(
+    query: Query<&LocalPlayerEvents>,
+    mut events: EventReader<KeepAliveEvent>,
+) {
     for event in events.read() {
         let local_player_events = query
             .get(event.entity)
@@ -222,7 +228,10 @@ fn keepalive_listener(query: Query<&LocalPlayerEvents>, mut events: EventReader<
     }
 }
 
-fn disconnect_listener(query: Query<&LocalPlayerEvents>, mut events: EventReader<DisconnectEvent>) {
+pub fn disconnect_listener(
+    query: Query<&LocalPlayerEvents>,
+    mut events: EventReader<DisconnectEvent>,
+) {
     for event in events.read() {
         if let Ok(local_player_events) = query.get(event.entity) {
             let _ = local_player_events.send(Event::Disconnect(event.reason.clone()));

--- a/azalea-client/src/lib.rs
+++ b/azalea-client/src/lib.rs
@@ -16,7 +16,7 @@ mod client;
 pub mod configuration;
 pub mod disconnect;
 mod entity_query;
-mod events;
+pub mod events;
 pub mod interact;
 pub mod inventory;
 mod local_player;

--- a/azalea-client/src/mining.rs
+++ b/azalea-client/src/mining.rs
@@ -418,7 +418,7 @@ pub struct FinishMiningBlockEvent {
     pub position: BlockPos,
 }
 
-fn handle_finish_mining_block_event(
+pub fn handle_finish_mining_block_event(
     mut events: EventReader<FinishMiningBlockEvent>,
     mut query: Query<(
         &InstanceName,
@@ -484,7 +484,7 @@ fn handle_finish_mining_block_event(
 pub struct StopMiningBlockEvent {
     pub entity: Entity,
 }
-fn handle_stop_mining_block_event(
+pub fn handle_stop_mining_block_event(
     mut events: EventReader<StopMiningBlockEvent>,
     mut send_packet_events: EventWriter<SendPacketEvent>,
     mut mine_block_progress_events: EventWriter<MineBlockProgressEvent>,
@@ -517,7 +517,7 @@ fn handle_stop_mining_block_event(
 }
 
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
-fn continue_mining_block(
+pub fn continue_mining_block(
     mut query: Query<(
         Entity,
         &InstanceName,

--- a/azalea/src/pathfinder/mod.rs
+++ b/azalea/src/pathfinder/mod.rs
@@ -139,7 +139,7 @@ pub struct PathFoundEvent {
 }
 
 #[allow(clippy::type_complexity)]
-fn add_default_pathfinder(
+pub fn add_default_pathfinder(
     mut commands: Commands,
     mut query: Query<Entity, (Without<Pathfinder>, With<LocalEntity>, With<Player>)>,
 ) {
@@ -193,7 +193,7 @@ impl PathfinderClientExt for azalea_client::Client {
 #[derive(Component)]
 pub struct ComputePath(Task<Option<PathFoundEvent>>);
 
-fn goto_listener(
+pub fn goto_listener(
     mut commands: Commands,
     mut events: EventReader<GotoEvent>,
     mut query: Query<(
@@ -340,7 +340,7 @@ fn goto_listener(
 }
 
 // poll the tasks and send the PathFoundEvent if they're done
-fn handle_tasks(
+pub fn handle_tasks(
     mut commands: Commands,
     mut transform_tasks: Query<(Entity, &mut ComputePath)>,
     mut path_found_events: EventWriter<PathFoundEvent>,
@@ -358,7 +358,7 @@ fn handle_tasks(
 }
 
 // set the path for the target entity when we get the PathFoundEvent
-fn path_found_listener(
+pub fn path_found_listener(
     mut events: EventReader<PathFoundEvent>,
     mut query: Query<(
         &mut Pathfinder,
@@ -446,7 +446,7 @@ fn path_found_listener(
     }
 }
 
-fn timeout_movement(
+pub fn timeout_movement(
     mut query: Query<(&Pathfinder, &mut ExecutingPath, &Position, Option<&Mining>)>,
 ) {
     for (pathfinder, mut executing_path, position, mining) in &mut query {
@@ -481,7 +481,7 @@ fn timeout_movement(
     }
 }
 
-fn check_node_reached(
+pub fn check_node_reached(
     mut query: Query<(
         Entity,
         &mut Pathfinder,
@@ -575,7 +575,7 @@ fn check_node_reached(
     }
 }
 
-fn check_for_path_obstruction(
+pub fn check_for_path_obstruction(
     mut query: Query<(&Pathfinder, &mut ExecutingPath, &InstanceName, &Inventory)>,
     instance_container: Res<InstanceContainer>,
 ) {
@@ -675,7 +675,7 @@ pub fn recalculate_near_end_of_path(
 }
 
 #[allow(clippy::type_complexity)]
-fn tick_execute_path(
+pub fn tick_execute_path(
     mut query: Query<(
         Entity,
         &mut ExecutingPath,
@@ -719,7 +719,7 @@ fn tick_execute_path(
     }
 }
 
-fn recalculate_if_has_goal_but_no_path(
+pub fn recalculate_if_has_goal_but_no_path(
     mut query: Query<(Entity, &mut Pathfinder), Without<ExecutingPath>>,
     mut goto_events: EventWriter<GotoEvent>,
 ) {
@@ -748,7 +748,7 @@ pub struct StopPathfindingEvent {
     pub force: bool,
 }
 
-fn handle_stop_pathfinding_event(
+pub fn handle_stop_pathfinding_event(
     mut events: EventReader<StopPathfindingEvent>,
     mut query: Query<(&mut Pathfinder, &mut ExecutingPath)>,
     mut walk_events: EventWriter<StartWalkEvent>,
@@ -782,7 +782,7 @@ fn handle_stop_pathfinding_event(
     }
 }
 
-fn stop_pathfinding_on_instance_change(
+pub fn stop_pathfinding_on_instance_change(
     mut query: Query<(Entity, &mut ExecutingPath), Changed<InstanceName>>,
     mut stop_pathfinding_events: EventWriter<StopPathfindingEvent>,
 ) {
@@ -800,7 +800,7 @@ fn stop_pathfinding_on_instance_change(
 
 /// Checks whether the path has been obstructed, and returns Some(index) if it
 /// has been. The index is of the first obstructed node.
-fn check_path_obstructed<SuccessorsFn>(
+pub fn check_path_obstructed<SuccessorsFn>(
     mut current_position: BlockPos,
     path: &VecDeque<astar::Movement<BlockPos, moves::MoveData>>,
     successors_fn: SuccessorsFn,


### PR DESCRIPTION
I think all the internal system handles should be public to resolve conflicts with before/after, but this is the ones that I've needed and changed so far.