### PR TITLE
Switch to u32 to match other entity ids in Azalea

### DIFF
--- a/azalea-protocol/src/packets/game/clientbound_add_entity_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_add_entity_packet.rs
@@ -16,7 +16,7 @@ pub struct ClientboundAddEntityPacket {
     pub y_rot: i8,
     pub y_head_rot: i8,
     #[var]
-    pub data: i32,
+    pub data: u32,
     pub x_vel: i16,
     pub y_vel: i16,
     pub z_vel: i16,

--- a/azalea-protocol/src/packets/game/clientbound_add_entity_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_add_entity_packet.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 pub struct ClientboundAddEntityPacket {
     /// The id of the entity.
     #[var]
-    pub id: i32,
+    pub id: u32,
     pub uuid: Uuid,
     pub entity_type: azalea_registry::EntityKind,
     pub position: Vec3,

--- a/azalea-protocol/src/packets/game/clientbound_add_entity_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_add_entity_packet.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 pub struct ClientboundAddEntityPacket {
     /// The id of the entity.
     #[var]
-    pub id: u32,
+    pub id: i32,
     pub uuid: Uuid,
     pub entity_type: azalea_registry::EntityKind,
     pub position: Vec3,


### PR DESCRIPTION
Should entity ids be `i32` instead of `u32` to match Java's int type? I don't know, and it doesn't seem to matter, this was the easier and lesser of the two options to pull request.