### PR TITLE
Fix accepting ResourcePacks during Configuration

### DIFF
--- a/azalea-client/src/packet_handling/configuration.rs
+++ b/azalea-client/src/packet_handling/configuration.rs
@@ -183,6 +183,12 @@ pub fn process_packet_events(ecs: &mut World) {
                         action: azalea_protocol::packets::configuration::serverbound_resource_pack_packet::Action::Accepted
                     }.get()
                 ).unwrap();
+                raw_connection.write_packet(
+                    ServerboundResourcePackPacket {
+                        id: p.id,
+                        action: azalea_protocol::packets::configuration::serverbound_resource_pack_packet::Action::SuccessfullyLoaded
+                    }.get()
+                ).unwrap();
             }
             ClientboundConfigurationPacket::ResourcePackPop(_) => {
                 // we can ignore this


### PR DESCRIPTION
Client will hang because it never reports successfully loading.

Should probably use `ResourcePackEvent` to accept these, but whatever.