### PR TITLE
Feat: Host Documentation for multiple versions/branch

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -41,18 +41,18 @@ jobs:
           rm -rf versioned_docs  # Clean up
           rm -rf target # Clean up
 
-      - name: Generate README.md
+      - name: Generate BRANCHES.md
         run: |
           VERSIONS=$(ls -d */ | sed 's#/##' | sort -r)  # Get all version directories and sort them (latest first)
           rm README.md # Delete README.md and generate a new one
-          echo "# Azalea Docs" > README.md
-          echo "Welcome to the documentation for Azalea Crate." >> README.md
-          echo "" >> README.md
+          echo "# Azalea Docs" > BRANCHES.md
+          echo "Welcome to the documentation for Azalea Crate." >> BRANCHES.md
+          echo "" >> BRANCHES.md
           
           # Update README.md with available versions
-          echo "## Available Versions" >> README.md
+          echo "## Available Versions" >> BRANCHES.md
           for VERSION in $VERSIONS; do
-            echo "- [$VERSION](./$VERSION/index.html)" >> README.md
+            echo "- [$VERSION](https://azalea.matdoes.dev/$VERSION/index.html)" >> BRANCHES.md
           done
 
           echo "README.md updated successfully."

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -56,6 +56,12 @@ jobs:
           done
 
           echo "README.md updated successfully."
+      
+      - name: Create Index Page
+        run: |
+          if [ ! -f index.html ]; then
+            echo "<meta http-equiv=refresh content=0;url=main/azalea>" > index.html
+          fi
 
       - name: Deploy Documentation to Docs Branch
         run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -41,21 +41,32 @@ jobs:
           rm -rf versioned_docs  # Clean up
           rm -rf target # Clean up
 
-      - name: Generate BRANCHES.md
+      - name: Generate branches.html
         run: |
           VERSIONS=$(ls -d */ | sed 's#/##' | sort -r)  # Get all version directories and sort them (latest first)
-          rm README.md # Delete README.md and generate a new one
-          echo "# Azalea Docs" > BRANCHES.md
-          echo "Welcome to the documentation for Azalea Crate." >> BRANCHES.md
-          echo "" >> BRANCHES.md
+          echo "<!DOCTYPE html>" > branches.html
+          echo "<html lang=\"en\">" >> branches.html
+          echo "<head>" >> branches.html
+          echo "  <meta charset=\"UTF-8\">" >> branches.html
+          echo "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">" >> branches.html
+          echo "  <title>Azalea Docs</title>" >> branches.html
+          echo "</head>" >> branches.html
+          echo "<body>" >> branches.html
+          echo "  <h1>Azalea Docs</h1>" >> branches.html
+          echo "  <p>Welcome to the documentation for Azalea Crate.</p>" >> branches.html
+          echo "  <h2>Available Versions</h2>" >> branches.html
+          echo "  <ul>" >> branches.html
           
-          # Update README.md with available versions
-          echo "## Available Versions" >> BRANCHES.md
+          # Update branches.html with available versions
           for VERSION in $VERSIONS; do
-            echo "- [$VERSION](https://azalea.matdoes.dev/$VERSION/index.html)" >> BRANCHES.md
-          done
+          echo "    <li><a href=\"https://azalea.matdoes.dev/$VERSION/index.html\">$VERSION</a></li>" >> branches.html
+            done
 
-          echo "README.md updated successfully."
+            echo "  </ul>" >> branches.html
+            echo "</body>" >> branches.html
+            echo "</html>" >> branches.html
+
+            echo "branches.html generated successfully."
       
       - name: Create Index Page
         run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,45 +1,61 @@
-name: Doc
+name: Generate Documentation
 
 on:
   push:
-    branches:
-      - main
   workflow_dispatch:
-
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
 
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+
+      - name: Install Rust Toolchain
+        uses: rs-workspace/rust-toolchain@v0.1.0
         with:
           toolchain: nightly
-      - run: cargo doc --workspace --no-deps
-      - uses: "finnp/create-file-action@master"
-        env:
-          FILE_NAME: "./target/doc/index.html"
-          FILE_DATA: '<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=''./azalea''"/></head></html>' # Redirect to default page
-    
-      - name: Setup Pages
-        uses: actions/configure-pages@v2
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: './target/doc/'
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+
+      - name: Generate Documentation
+        run: RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --workspace --no-deps
+
+      - name: Prepare Documentation
+        run: |
+          BRANCH_NAME=$(echo "${GITHUB_REF##*/}" | tr '/' '_')  # Get branch name safely
+          mkdir -p versioned_docs/$BRANCH_NAME
+          cp -r target/doc/* versioned_docs/$BRANCH_NAME
+
+      - name: Checkout to Docs Branch
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin docs || git checkout --orphan docs
+          git checkout docs
+          cp -r versioned_docs/* ./  # Copy docs to branch root
+          rm -rf versioned_docs  # Clean up
+          rm -rf target # Clean up
+
+      - name: Generate README.md
+        run: |
+          VERSIONS=$(ls -d */ | sed 's#/##' | sort -r)  # Get all version directories and sort them (latest first)
+          rm README.md # Delete README.md and generate a new one
+          echo "# Azalea Docs" > README.md
+          echo "Welcome to the documentation for Azalea Crate." >> README.md
+          echo "" >> README.md
+          
+          # Update README.md with available versions
+          echo "## Available Versions" >> README.md
+          for VERSION in $VERSIONS; do
+            echo "- [$VERSION](./$VERSION/index.html)" >> README.md
+          done
+
+          echo "README.md updated successfully."
+
+      - name: Deploy Documentation to Docs Branch
+        run: |
+          git add .
+          git commit -m "Update documentation for $GITHUB_REF_NAME" || echo "No changes to commit"
+          git push origin docs

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,6 +2,9 @@ name: Generate Documentation
 
 on:
   push:
+    branches:
+      - main
+      - '*.*.*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
I love azalea, and sometimes I need to use different branch of azalea like `1.20.4`. The issue is that azalea, currently only hosts documentation for `main` branch and though it would be great if it supported documentation multiple branches. This is what this PR introduces.

A Demo is available at https://as1100k.github.io/azalea/ [Old due to changes requested]

## Prerequisite
1. Create a [orphan branch](https://stackoverflow.com/questions/1384325/in-git-is-there-a-simple-way-of-introducing-an-unrelated-branch-to-a-repository#:~:text=git%20checkout%20%2D%2Dorphan%20newbranch%0Agit%20rm%20%2Drf%20.%0A%3Cdo%20work%3E%0Agit%20add%20your%20files%0Agit%20commit%20%2Dm%20%27Initial%20commit%27) `docs`. And a `Initial Commit` with `.gitignore` with the following content:
    ```
    target
    ```
2. Update `doc.yml` for old branches. _(If you approve, I will open PR for all those other branches)_
3. Change settings to host GitHub Pages from `docs` branch instead of `GitHub Actions`