### PR TITLE
chore(core): Derive Serialize and Deserialize for `direction` types

### DIFF
--- a/azalea-core/src/direction.rs
+++ b/azalea-core/src/direction.rs
@@ -3,6 +3,7 @@ use azalea_buf::AzBuf;
 use crate::position::Vec3;
 
 #[derive(Clone, Copy, Debug, AzBuf, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Direction {
     #[default]
     Down = 0,
@@ -63,6 +64,7 @@ impl Direction {
 
 // TODO: make azalea_block use this instead of FacingCardinal
 #[derive(Clone, Copy, Debug, AzBuf, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum CardinalDirection {
     North,
     South,


### PR DESCRIPTION
Derive serde's Serialize and Deserialize for `direction` types when crate's `serde` feature is enabled.

Not a big change but is a continuation of #183 , #179 and #175