### PR TITLE
update dead wiki.vg links

### DIFF
--- a/azalea-auth/README.md
+++ b/azalea-auth/README.md
@@ -24,4 +24,4 @@ async fn main() {
 }
 ```
 
-Thanks to [wiki.vg contributors](https://wiki.vg/Microsoft_Authentication_Scheme), [Overhash](https://gist.github.com/OverHash/a71b32846612ba09d8f79c9d775bfadf), and [prismarine-auth contributors](https://github.com/PrismarineJS/prismarine-auth).
+Thanks to [wiki contributors](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Microsoft_Authentication_Scheme), [Overhash](https://gist.github.com/OverHash/a71b32846612ba09d8f79c9d775bfadf), and [prismarine-auth contributors](https://github.com/PrismarineJS/prismarine-auth).

--- a/azalea-client/src/plugins/packet/game/mod.rs
+++ b/azalea-client/src/plugins/packet/game/mod.rs
@@ -1248,7 +1248,7 @@ impl GamePacketHandler<'_> {
         // TODO: handle ContainerSetData packet
         // this is used for various things like the furnace progress
         // bar
-        // see https://wiki.vg/Protocol#Set_Container_Property
+        // see https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol#Set_Container_Property
 
         // as_system::<Query<&mut Inventory>>(self.ecs, |mut query| {
         //     let inventory = query.get_mut(self.player).unwrap();

--- a/azalea-protocol/README.md
+++ b/azalea-protocol/README.md
@@ -12,11 +12,11 @@ Unfortunately, using azalea-protocol requires Rust nightly because [specializati
 
 Adding new packets is usually pretty easy, but you'll want to have Minecraft's decompiled source code which you can obtain with tools such as [DecompilerMC](https://github.com/hube12/DecompilerMC).
 
-1. First, you'll need the packet id. You can get this from azalea-protocol error messages or from wiki.vg.
+1. First, you'll need the packet id. You can get this from azalea-protocol error messages or from [the wiki](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge).
 2. Run `python codegen/newpacket.py [packet id] [clientbound or serverbound] \[game/handshake/login/status\]`\
 3. Go to the directory where it told you the packet was generated. If there's no comments, you're done. Otherwise, keep going.
 4. Find the packet in Minecraft's source code. Minecraft's packets are in the `net/minecraft/network/protocol/<state>` directory. The state for your packet is usually `game`.
-5. Add the fields from Minecraft's source code from either the read or write methods. You can look at [wiki.vg](https://wiki.vg/Protocol) if you're not sure about how a packet is structured, but be aware that wiki.vg uses different names for most things.
+5. Add the fields from Minecraft's source code from either the read or write methods. You can look at [the wiki](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol) if you're not sure about how a packet is structured, but be aware that the wiki uses different names for most things.
 6. Format the code, submit a pull request, and wait for it to be reviewed.
 
 ### Implementing packets

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -40,7 +40,7 @@ If it all works, make a pull request. If the version you updated to is a snapsho
 
 At the time of writing, the following data generators are used:
 
--   [Vanilla data generator](https://wiki.vg/Data_Generators)
+-   [Vanilla data generator](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Data_Generators)
 -   [Burger](https://github.com/mat-1/Burger)
 -   [PixLyzer](https://gitlab.bixilon.de/bixilon/pixlyzer)
 


### PR DESCRIPTION
Since wiki.vg is now [offline](https://tkte.ch/articles/2024/11/11/sunsetting.html), I've replaced all links with their counterparts on `https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge`