### PR TITLE
remove `.unwrap()` from `wait_until_goto_target_reached`

### DIFF
--- a/azalea/src/pathfinder/mod.rs
+++ b/azalea/src/pathfinder/mod.rs
@@ -40,6 +40,7 @@ use futures_lite::future;
 use goals::BlockPosGoal;
 use parking_lot::RwLock;
 use rel_block_pos::RelBlockPos;
+use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, error, info, trace, warn};
 
 pub use self::debug::PathfinderDebugParticles;
@@ -253,7 +254,11 @@ impl PathfinderClientExt for azalea_client::Client {
         let mut tick_broadcaster = self.get_tick_broadcaster();
         while !self.is_goto_target_reached() {
             // check every tick
-            tick_broadcaster.recv().await.unwrap();
+            match tick_broadcaster.recv().await {
+                Ok(_) => (),
+                Err(RecvError::Closed) => return,
+                Err(err) => eprintln!("{err}"),
+            };
         }
     }
 

--- a/azalea/src/pathfinder/mod.rs
+++ b/azalea/src/pathfinder/mod.rs
@@ -257,7 +257,7 @@ impl PathfinderClientExt for azalea_client::Client {
             match tick_broadcaster.recv().await {
                 Ok(_) => (),
                 Err(RecvError::Closed) => return,
-                Err(err) => eprintln!("{err}"),
+                Err(err) => warn!("{err}"),
             };
         }
     }


### PR DESCRIPTION
sometimes the tick broadcaster would lag and would cause the entire thread to panic with `Lagged(1)`