### PR TITLE
Named TextColor must be lowercase

### DIFF
--- a/azalea-chat/src/style.rs
+++ b/azalea-chat/src/style.rs
@@ -268,7 +268,7 @@ impl TextColor {
 
     fn serialize(&self) -> String {
         if let Some(name) = &self.name {
-            name.clone()
+            name.clone().to_ascii_lowercase()
         } else {
             self.format_value()
         }


### PR DESCRIPTION
```rust
use azalea_chat::{style::{ChatFormatting, TextColor}, text_component::TextComponent};
use serde_json::value::Serializer;
use serde::Serialize;

fn main() {
    let mut t = TextComponent::new("Some content".to_owned());
    t.base.style.color = Some(TextColor::try_from(ChatFormatting::Red).unwrap());
    println!("{}", TextComponent::serialize(&t, Serializer).unwrap());
}
```
azalea 0.11.0 produces: `{"color":"red","text":"Some content"}`
azalea 0.12.0 produces: `{"color":"RED","text":"Some content"}`

The component produced by 0.12.0 is invalid:
![image](https://github.com/user-attachments/assets/1d38190e-471d-4698-8c8b-b8683c4c9955)
