### PR TITLE
fix: parse int lists in TranslatableComponent `with` field

### DIFF
--- a/azalea-chat/src/component.rs
+++ b/azalea-chat/src/component.rs
@@ -437,6 +437,10 @@ impl FormattedText {
                     for item in with {
                         with_array.push(StringOrComponent::String(item.to_string()));
                     }
+                } else if let Some(with) = with_list.ints() {
+                    for item in with {
+                        with_array.push(StringOrComponent::String(item.to_string()));
+                    }
                 } else if let Some(with) = with_list.compounds() {
                     for item in with {
                         // if it's a string component with no styling and no siblings,


### PR DESCRIPTION
### Fix: system_chat parsing with `with: list<int>`

azalea previously errored when the server sent a system_chat packet where the `with` field was a `list<int>`.
(e.g. /fill command)

For example, it would log:
```
WARN azalea_chat::component: couldn't parse NbtTag as FormattedText because it's not a list of compounds
ERROR azalea_client::plugins::connection: Error reading packet: couldn't convert nbt to chat message
```

Now, these are parsed as:
```
args: [String("8")]
```

---

#### Reference (using minecraft-protocol test):

```js
import pkg from 'minecraft-protocol';
const { createDeserializer, states } = pkg;
const deserializer = createDeserializer({
  state: states.PLAY,
  isServer: false,
  version: '1.21.4' //latest minecraft-protocol supported version
});
const packetBuffer = Buffer.from([
// Minecraft 1.21.6  head 115 -> 114
  115, 10, 9, 0, 4, 119, 105, 116, 104, 3, 0, 0, 0, 1, 0, 0, 0, 8, 8, 0, 9, 116, 114, 97, 110, 115, 108, 97, 116, 101, 0, 21, 99, 111, 109, 109,
  97, 110, 100, 115, 46, 102, 105, 108, 108, 46, 115, 117, 99, 99, 101, 115, 115, 0, 0
]);
const packet = deserializer.parsePacketBuffer(packetBuffer).data;
console.dir(packet, { depth: null });
// Output:
// {
//   name: 'system_chat',
//   params: {
//     content: {
//       type: 'compound',
//       value: {                                                   ↓↓↓↓↓
//         with: { type: 'list', value: { type: 'int', value: [ 8 ] } },
//         translate: { type: 'string', value: 'commands.fill.success' }
//       }
//     },
//     isActionBar: false
//   }
// }
```