### PR TITLE
Add best effort for default max stack sizes

### DIFF
--- a/azalea-inventory/src/item/mod.rs
+++ b/azalea-inventory/src/item/mod.rs
@@ -60,7 +60,7 @@ impl MaxStackSizeExt for azalea_registry::Item {
             || name.ends_with("_soup")
             || name.ends_with("_bundle")
             || name.contains("music_disc_")
-            || name.contains("_bed")
+            || name.ends_with("_bed")
         {
             1
         } else if [Self::Bucket, Self::EnderPearl, Self::Snowball, Self::Egg, Self::ArmorStand, Self::WrittenBook].contains(self)

--- a/azalea-inventory/src/item/mod.rs
+++ b/azalea-inventory/src/item/mod.rs
@@ -19,7 +19,57 @@ pub trait MaxStackSizeExt {
 
 impl MaxStackSizeExt for azalea_registry::Item {
     fn max_stack_size(&self) -> i32 {
-        // TODO: have the properties for every item defined somewhere
-        64
+        // Best effort, might have forgotten some niche item
+        let name = self.to_string();
+        if [
+            Self::ShulkerBox,
+            Self::Potion,
+            Self::SplashPotion,
+            Self::LingeringPotion,
+            Self::AxolotlBucket,
+            Self::Minecart,
+            Self::Trident,
+            Self::Mace,
+            Self::Bow,
+            Self::Crossbow,
+            Self::TotemOfUndying,
+            Self::Shield,
+            Self::Cake,
+            Self::Shears,
+            Self::Bundle,
+            Self::EnchantedBook,
+            Self::DebugStick,
+            Self::WritableBook,
+        ]
+            .contains(self)
+            || name.ends_with("_shulker_box")
+            || name.ends_with("_bucket")
+            || name.ends_with("_pattern")
+            || name.ends_with("_minecart")
+            || name.ends_with("_boat")
+            || name.ends_with("_helmet")
+            || name.ends_with("_leggings")
+            || name.ends_with("_chestplate")
+            || name.ends_with("_boots")
+            || name.ends_with("_sword")
+            || name.ends_with("_axe")
+            || name.ends_with("_pickaxe")
+            || name.ends_with("_shovel")
+            || name.ends_with("_hoe")
+            || name.ends_with("_horse_armor")
+            || name.ends_with("_soup")
+            || name.ends_with("_bundle")
+            || name.contains("music_disc_")
+            || name.contains("_bed")
+        {
+            1
+        } else if [Self::Bucket, Self::EnderPearl, Self::Snowball, Self::Egg, Self::ArmorStand, Self::WrittenBook].contains(self)
+            || name.ends_with("_sign")
+            || name.ends_with("_banner")
+        {
+            16
+        } else {
+            64
+        }
     }
 }


### PR DESCRIPTION
Maybe useful, was implementing a bunch of inventory things and noticed this info missing, which can cause issues with click simulation.

This is by no means 100%, but I'd like to think it's close to 100% complete.

Not pretty code, but should get the job done until some better way is decided on.