### PR TITLE
Improve System Chat Regex & Add System Whisper Regex

### DIFF
--- a/azalea-client/src/plugins/chat/mod.rs
+++ b/azalea-client/src/plugins/chat/mod.rs
@@ -70,7 +70,7 @@ impl ChatPacket {
                 }
 
                 // It's a system message, so we'll have to match the content with regex
-                if let Some(m) = regex!("^<(?[a-zA-Z_0-9]{1,16})> (?:-> me)?(?.+)$").captures(&message) {
+                if let Some(m) = regex!("^<([a-zA-Z_0-9]{1,16})> (?:-> me)?(.+)$").captures(&message) {
                     return (Some(m[1].to_string()), m[2].to_string());
                 }
 
@@ -139,7 +139,7 @@ impl ChatPacket {
                 }
 
                 // It's a system message, so we'll have to match the content with regex
-                if let Some(m) = regex!("^(?-> me)?(?:.+)$").captures(&message) {
+                if let Some(m) = regex!("^(-> me)?(?:.+)$").captures(&message) {
                     return m.get(1).is_some();
                 }
 


### PR DESCRIPTION
This separates the system chat sender/content splitting regex and adds a system chat whisper regex which can both be overridden to add custom server chat format parsing, the built-in ones support Vanilla and Essentials Chat, and now use capture group names so that really weird formats with out of order groups can still be parsed (such as content, then sender)