### PR TITLE
make `handle_menu_opened_event` public

### DIFF
--- a/azalea/src/container.rs
+++ b/azalea/src/container.rs
@@ -267,7 +267,7 @@ impl ContainerHandle {
 #[derive(Component, Debug)]
 pub struct WaitingForInventoryOpen;
 
-fn handle_menu_opened_event(
+pub fn handle_menu_opened_event(
     mut commands: Commands,
     mut events: EventReader<ReceiveGamePacketEvent>,
 ) {


### PR DESCRIPTION
This change was made so people can actually add systems before or after this