### PR TITLE
fix(protocol): update 1.21.9 ClientboundSetDefaultSpawnPosition fields

### DIFF
--- a/azalea-protocol/src/packets/game/c_set_default_spawn_position.rs
+++ b/azalea-protocol/src/packets/game/c_set_default_spawn_position.rs
@@ -1,9 +1,10 @@
 use azalea_buf::AzBuf;
-use azalea_core::position::BlockPos;
+use azalea_core::position::GlobalPos;
 use azalea_protocol_macros::ClientboundGamePacket;
 
 #[derive(Clone, Debug, AzBuf, PartialEq, ClientboundGamePacket)]
 pub struct ClientboundSetDefaultSpawnPosition {
-    pub pos: BlockPos,
-    pub angle: f32,
+    pub global_pos: GlobalPos,
+    pub yaw: f32,
+    pub pitch: f32,
 }


### PR DESCRIPTION
this works on my machine :3 
```
ClientboundSetDefaultSpawnPosition { 
                     global_pos: GlobalPos { 
                                     dimension: minecraft:overworld, 
                                     pos: BlockPos { x: 17, y: -59, z: 37 }
                    }, 
                   yaw: 0.0, 
                   pitch: 0.0 }
```
## issue:
` 2025-10-02T04:13:24.790870Z ERROR azalea_client::plugins::connection: Error reading packet: Leftover data after reading packet set_default_spawn_position: [118, 101, 114, 119, 111, 114, 108, 100, 0, 0, 4, 64, 0, 2, 95, 197, 0, 0, 0, 0, 0, 0, 0, 0]
`

```rust
pub struct ClientboundSetDefaultSpawnPosition {
    pub pos: BlockPos,        
    pub angle: f32,
}
```
## solution:
```
pub struct ClientboundSetDefaultSpawnPosition {
    pub global_pos: GlobalPos,
    pub yaw: f32,
    pub pitch: f32,
}
## source ref：
  - `net/minecraft/network/packet/s2c/play/PlayerSpawnPositionS2CPacket.java`
  - `net/minecraft/world/WorldProperties.java` 
  - `net/minecraft/util/math/GlobalPos.java`


