### PR TITLE
Add cache_key alias to avoid re-auth

### DIFF
--- a/azalea-auth/src/cache.rs
+++ b/azalea-auth/src/cache.rs
@@ -28,6 +28,7 @@ pub enum CacheError {
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct CachedAccount {
+    #[serde(alias = "email")]
     pub cache_key: String,
     /// Microsoft auth
     pub msa: ExpiringValue<crate::auth::AccessTokenResponse>,


### PR DESCRIPTION
This will look for the email field as a fallback if cache_key isn't found, to avoid having to re-authenticate, it should re-save it as cache_key on the next write.

https://github.com/azalea-rs/azalea/commit/c811dc471a31175d985e2d448a772c628dcad5f6