### PR TITLE
Fix assertion message

### DIFF
--- a/azalea-core/src/bitset.rs
+++ b/azalea-core/src/bitset.rs
@@ -52,7 +52,7 @@ impl BitSet {
     pub fn clear(&mut self, range: Range<usize>) {
         assert!(
             range.start <= range.end,
-            "Range ends before it starts; {} must be greater than {}",
+            "Range ends before it starts; {} must be less than or equal to {}",
             range.start,
             range.end
         );


### PR DESCRIPTION
In azalea/azalea-core/src/bitset.rs, the assertion's message "range.start must be greater than range.end" is wrong. It should be "range.start must be less than or equal to range.end" instead.
```rust
/// # Panics
    ///
    /// Panics if the range is invalid (start > end).
    pub fn clear(&mut self, range: Range<usize>) {
        assert!(
            range.start <= range.end,
            "Range ends before it starts; {} must be greater than {}",
            range.start,
            range.end
        );
...
```