### PR TITLE
Use MinecraftEntityId in ClientboundSetPassengers packet

### DIFF
--- a/azalea-protocol/src/packets/game/c_set_passengers.rs
+++ b/azalea-protocol/src/packets/game/c_set_passengers.rs
@@ -1,10 +1,11 @@
 use azalea_buf::AzBuf;
 use azalea_protocol_macros::ClientboundGamePacket;
+use azalea_world::MinecraftEntityId;
 
 #[derive(Clone, Debug, AzBuf, PartialEq, ClientboundGamePacket)]
 pub struct ClientboundSetPassengers {
     #[var]
-    pub vehicle: u32,
+    pub vehicle: MinecraftEntityId,
     #[var]
-    pub passengers: Vec<u32>,
+    pub passengers: Vec<MinecraftEntityId>,
 }


### PR DESCRIPTION
Technically this has no effect since a negative `i32` would just wrap around to be a large `u32`, but it's good to use the existing explicit type for this.

Fixes #290 