### PR TITLE
Rename Instance to World

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ is breaking anyways, semantic versioning is not followed.
 
 ### Changed
 
+- Rename `Instance` to `World` (and rename other related types).
 - Move the `Client` struct out of `azalea-client` into `azalea`.
 - `Client::ecs` is now an `RwLock` instead of a `Mutex`.
 - `Client::component` and `entity_component` now return a mapped RwLock guard instead of cloning the component.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,7 @@ dependencies = [
  "azalea-inventory",
  "azalea-protocol-macros",
  "azalea-registry",
+ "azalea-world",
  "bevy_ecs",
  "flate2",
  "futures",

--- a/azalea-client/src/client.rs
+++ b/azalea-client/src/client.rs
@@ -11,7 +11,7 @@ use azalea_entity::{
     EntityUpdateSystems, PlayerAbilities, indexing::EntityIdIndex, inventory::Inventory,
 };
 use azalea_physics::local_player::PhysicsState;
-use azalea_world::InstanceContainer;
+use azalea_world::Worlds;
 use bevy_app::{App, AppExit, Plugin, PluginsState, SubApp, Update};
 use bevy_ecs::{
     message::MessageCursor,
@@ -29,7 +29,7 @@ use crate::{
     connection::RawConnection,
     cookies::ServerCookies,
     interact::BlockStatePredictionHandler,
-    local_player::{Hunger, InstanceHolder, PermissionLevel, TabList},
+    local_player::{Hunger, PermissionLevel, TabList, WorldHolder},
     mining,
     movement::LastSentLookDirection,
     player::retroactively_add_game_profile_component,
@@ -43,7 +43,7 @@ use crate::{
 #[derive(Bundle)]
 pub struct LocalPlayerBundle {
     pub raw_connection: RawConnection,
-    pub instance_holder: InstanceHolder,
+    pub world_holder: WorldHolder,
 
     pub metadata: azalea_entity::metadata::PlayerMetadataBundle,
 }
@@ -56,7 +56,7 @@ pub struct LocalPlayerBundle {
 /// If you want to filter for this, use [`InGameState`].
 #[derive(Bundle, Default)]
 pub struct JoinedClientBundle {
-    // note that InstanceHolder isn't here because it's set slightly before we fully join the world
+    // note that WorldHolder isn't here because it's set slightly before we fully join the world
     pub physics_state: PhysicsState,
     pub inventory: Inventory,
     pub tab_list: TabList,
@@ -98,7 +98,7 @@ impl Plugin for AzaleaPlugin {
                     .after(crate::join::handle_start_join_server_event),
             ),
         )
-        .init_resource::<InstanceContainer>()
+        .init_resource::<Worlds>()
         .init_resource::<TabList>();
     }
 }

--- a/azalea-client/src/plugins/block_update.rs
+++ b/azalea-client/src/plugins/block_update.rs
@@ -5,7 +5,7 @@ use bevy_ecs::prelude::*;
 
 use crate::{
     chunks::handle_receive_chunk_event, interact::BlockStatePredictionHandler,
-    local_player::InstanceHolder,
+    local_player::WorldHolder,
 };
 
 pub struct BlockUpdatePlugin;
@@ -34,12 +34,12 @@ pub struct QueuedServerBlockUpdates {
 pub fn handle_block_update_event(
     mut query: Query<(
         &mut QueuedServerBlockUpdates,
-        &InstanceHolder,
+        &WorldHolder,
         &mut BlockStatePredictionHandler,
     )>,
 ) {
-    for (mut queued, instance_holder, mut prediction_handler) in query.iter_mut() {
-        let world = instance_holder.instance.read();
+    for (mut queued, world_holder, mut prediction_handler) in query.iter_mut() {
+        let world = world_holder.shared.read();
         for (pos, block_state) in queued.list.drain(..) {
             if !prediction_handler.update_known_server_state(pos, block_state) {
                 world.chunks.set_block_state(pos, block_state);

--- a/azalea-client/src/plugins/disconnect.rs
+++ b/azalea-client/src/plugins/disconnect.rs
@@ -1,10 +1,10 @@
 //! Disconnect a client from the server.
 
 use azalea_chat::FormattedText;
+use azalea_core::entity_id::MinecraftEntityId;
 use azalea_entity::{
     EntityBundle, HasClientLoaded, InLoadedChunk, LocalEntity, metadata::PlayerMetadataBundle,
 };
-use azalea_core::entity_id::MinecraftEntityId;
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_ecs::prelude::*;
 use derive_more::Deref;
@@ -14,7 +14,7 @@ use super::login::IsAuthenticated;
 #[cfg(feature = "online-mode")]
 use crate::chat_signing;
 use crate::{
-    client::JoinedClientBundle, connection::RawConnection, local_player::InstanceHolder,
+    client::JoinedClientBundle, connection::RawConnection, local_player::WorldHolder,
     tick_counter::TicksConnected,
 };
 
@@ -63,7 +63,7 @@ pub struct RemoveOnDisconnectBundle {
 
     pub entity: EntityBundle,
     pub minecraft_entity_id: MinecraftEntityId,
-    pub instance_holder: InstanceHolder,
+    pub world_holder: WorldHolder,
     pub player_metadata: PlayerMetadataBundle,
     pub in_loaded_chunk: InLoadedChunk,
     //// This makes it close the TCP connection.

--- a/azalea-client/src/plugins/interact/mod.rs
+++ b/azalea-client/src/plugins/interact/mod.rs
@@ -30,7 +30,7 @@ use azalea_protocol::packets::game::{
     s_swing::ServerboundSwing,
     s_use_item_on::ServerboundUseItemOn,
 };
-use azalea_world::Instance;
+use azalea_world::World;
 use bevy_app::{App, Plugin, Update};
 use bevy_ecs::prelude::*;
 use tracing::warn;
@@ -140,7 +140,7 @@ impl BlockStatePredictionHandler {
         }
     }
 
-    pub fn end_prediction_up_to(&mut self, seq: u32, world: &Instance) {
+    pub fn end_prediction_up_to(&mut self, seq: u32, world: &World) {
         let mut to_remove = Vec::new();
         for (pos, state) in &self.server_state {
             if state.seq > seq {
@@ -377,10 +377,10 @@ pub fn handle_entity_interact(
 ///
 /// If this is false, then we can interact with the block.
 ///
-/// Passing the inventory, block position, and instance is necessary for the
-/// adventure mode check.
+/// The world, block position, and inventory are used for the adventure mode
+/// check.
 pub fn check_is_interaction_restricted(
-    instance: &Instance,
+    world: &World,
     block_pos: BlockPos,
     game_mode: &GameMode,
     inventory: &Inventory,
@@ -393,7 +393,7 @@ pub fn check_is_interaction_restricted(
             let held_item = inventory.held_item();
             match &held_item {
                 ItemStack::Present(item) => {
-                    let block = instance.chunks.get_block_state(block_pos);
+                    let block = world.chunks.get_block_state(block_pos);
                     let Some(block) = block else {
                         // block isn't loaded so just say that it is restricted
                         return true;

--- a/azalea-client/src/plugins/interact/pick.rs
+++ b/azalea-client/src/plugins/interact/pick.rs
@@ -17,7 +17,7 @@ use azalea_physics::{
     clip::{BlockShapeType, ClipContext, FluidPickType},
     collision::entity_collisions::{AabbQuery, get_entities},
 };
-use azalea_world::{Instance, InstanceContainer, InstanceName};
+use azalea_world::{World, WorldName, Worlds};
 use bevy_ecs::prelude::*;
 use derive_more::{Deref, DerefMut};
 
@@ -37,13 +37,13 @@ pub fn update_hit_result_component(
             &Position,
             &EntityDimensions,
             &LookDirection,
-            &InstanceName,
+            &WorldName,
             &Physics,
             &Attributes,
         ),
         With<LocalEntity>,
     >,
-    instance_container: Res<InstanceContainer>,
+    worlds: Res<Worlds>,
     aabb_query: AabbQuery,
     pickable_query: MaybePickableEntityQuery,
 ) {
@@ -63,7 +63,7 @@ pub fn update_hit_result_component(
 
         let eye_position = position.up(dimensions.eye_height.into());
 
-        let Some(world_lock) = instance_container.get(world_name) else {
+        let Some(world_lock) = worlds.get(world_name) else {
             continue;
         };
         let world = world_lock.read();
@@ -117,7 +117,7 @@ pub struct PickOpts<'world, 'state, 'a, 'b, 'c> {
     look_direction: LookDirection,
     eye_position: Vec3,
     aabb: &'a Aabb,
-    world: &'a Instance,
+    world: &'a World,
     entity_pick_range: f64,
     block_pick_range: f64,
     aabb_query: &'a AabbQuery<'world, 'state, 'b>,
@@ -246,7 +246,7 @@ struct PickEntityOpts<'world, 'state, 'a, 'b> {
     source_entity: Entity,
     eye_position: Vec3,
     end_position: Vec3,
-    world: &'a azalea_world::Instance,
+    world: &'a azalea_world::World,
     pick_range_squared: f64,
     predicate: &'a dyn Fn(Entity) -> bool,
     aabb: &'a Aabb,

--- a/azalea-client/src/plugins/inventory/mod.rs
+++ b/azalea-client/src/plugins/inventory/mod.rs
@@ -11,7 +11,7 @@ use azalea_protocol::packets::game::{
     s_set_carried_item::ServerboundSetCarriedItem,
 };
 use azalea_registry::builtin::MenuKind;
-use azalea_world::{InstanceContainer, InstanceName};
+use azalea_world::{WorldName, Worlds};
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
 use indexmap::IndexMap;
@@ -167,10 +167,10 @@ pub struct ContainerClickEvent {
 pub fn handle_container_click_event(
     container_click: On<ContainerClickEvent>,
     mut commands: Commands,
-    mut query: Query<(Entity, &mut Inv, Option<&PlayerAbilities>, &InstanceName)>,
-    instance_container: Res<InstanceContainer>,
+    mut query: Query<(Entity, &mut Inv, Option<&PlayerAbilities>, &WorldName)>,
+    worlds: Res<Worlds>,
 ) {
-    let (entity, mut inventory, player_abilities, instance_name) =
+    let (entity, mut inventory, player_abilities, world_name) =
         query.get_mut(container_click.entity).unwrap();
     if inventory.id != container_click.window_id {
         error!(
@@ -180,7 +180,7 @@ pub fn handle_container_click_event(
         return;
     }
 
-    let Some(instance) = instance_container.get(instance_name) else {
+    let Some(world) = worlds.get(world_name) else {
         return;
     };
 
@@ -191,7 +191,7 @@ pub fn handle_container_click_event(
     );
     let new_slots = inventory.menu().slots();
 
-    let registry_holder = &instance.read().registries;
+    let registry_holder = &world.read().registries;
 
     // see which slots changed after clicking and put them in the map the server
     // uses this to check if we desynced

--- a/azalea-client/src/plugins/join.rs
+++ b/azalea-client/src/plugins/join.rs
@@ -11,7 +11,7 @@ use azalea_protocol::{
         login::{ClientboundLoginPacket, ServerboundHello, ServerboundLoginPacket},
     },
 };
-use azalea_world::Instance;
+use azalea_world::World;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_tasks::{IoTaskPool, Task, futures_lite::future};
@@ -23,6 +23,7 @@ use crate::{
     LocalPlayerBundle,
     account::Account,
     connection::RawConnection,
+    local_player::WorldHolder,
     packet::login::{InLoginState, SendLoginPacketEvent},
 };
 
@@ -204,12 +205,12 @@ pub fn poll_create_connection_task(
             let (read_conn, write_conn) = conn.into_split();
             let (read_conn, write_conn) = (read_conn.raw, write_conn.raw);
 
-            let instance = Instance::default();
-            let instance_holder = crate::local_player::InstanceHolder::new(
+            let world = World::default();
+            let world_holder = WorldHolder::new(
                 entity,
                 // default to an empty world, it'll be set correctly later when we
                 // get the login packet
-                Arc::new(RwLock::new(instance)),
+                Arc::new(RwLock::new(world)),
             );
 
             entity_mut.insert((
@@ -220,7 +221,7 @@ pub fn poll_create_connection_task(
                         write_conn,
                         ConnectionProtocol::Login,
                     ),
-                    instance_holder,
+                    world_holder,
                     metadata: azalea_entity::metadata::PlayerMetadataBundle::default(),
                 },
                 InLoginState,

--- a/azalea-client/src/plugins/movement.rs
+++ b/azalea-client/src/plugins/movement.rs
@@ -31,12 +31,12 @@ use azalea_protocol::{
     },
 };
 use azalea_registry::builtin::EntityKind;
-use azalea_world::Instance;
+use azalea_world::World;
 use bevy_app::{App, Plugin, Update};
 use bevy_ecs::prelude::*;
 
 use crate::{
-    local_player::{Hunger, InstanceHolder, LocalGameMode},
+    local_player::{Hunger, LocalGameMode, WorldHolder},
     packet::game::SendGamePacketEvent,
 };
 
@@ -296,7 +296,7 @@ pub fn local_player_ai_step(
             &PlayerAbilities,
             &metadata::Swimming,
             &metadata::SleepingPos,
-            &InstanceHolder,
+            &WorldHolder,
             &Position,
             Option<&Hunger>,
             Option<&LastSentInput>,
@@ -316,7 +316,7 @@ pub fn local_player_ai_step(
         abilities,
         swimming,
         sleeping_pos,
-        instance_holder,
+        world_holder,
         position,
         hunger,
         last_sent_input,
@@ -333,7 +333,7 @@ pub fn local_player_ai_step(
         let is_passenger = false;
         let is_sleeping = sleeping_pos.is_some();
 
-        let world = instance_holder.instance.read();
+        let world = world_holder.shared.read();
         let ctx = CanPlayerFitCtx {
             world: &world,
             entity,
@@ -587,16 +587,16 @@ pub fn update_pose(
         &Physics,
         &PhysicsState,
         &LocalGameMode,
-        &InstanceHolder,
+        &WorldHolder,
         &Position,
     )>,
     aabb_query: AabbQuery,
     collidable_entity_query: CollidableEntityQuery,
 ) {
-    for (entity, mut pose, physics, physics_state, game_mode, instance_holder, position) in
+    for (entity, mut pose, physics, physics_state, game_mode, world_holder, position) in
         query.iter_mut()
     {
-        let world = instance_holder.instance.read();
+        let world = world_holder.shared.read();
         let world = &*world;
         let ctx = CanPlayerFitCtx {
             world,
@@ -642,7 +642,7 @@ pub fn update_pose(
 }
 
 struct CanPlayerFitCtx<'world, 'state, 'a, 'b> {
-    world: &'a Instance,
+    world: &'a World,
     entity: Entity,
     position: Position,
     aabb_query: &'a AabbQuery<'world, 'state, 'b>,

--- a/azalea-client/src/plugins/packet/config/mod.rs
+++ b/azalea-client/src/plugins/packet/config/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     connection::RawConnection,
     cookies::{RequestCookieEvent, StoreCookieEvent},
     disconnect::DisconnectEvent,
-    local_player::InstanceHolder,
+    local_player::WorldHolder,
     packet::game::{KeepAliveEvent, ResourcePackEvent},
 };
 
@@ -69,12 +69,12 @@ pub struct ConfigPacketHandler<'a> {
 }
 impl ConfigPacketHandler<'_> {
     pub fn registry_data(&mut self, p: &ClientboundRegistryData) {
-        as_system::<Query<&InstanceHolder>>(self.ecs, |mut query| {
-            let instance_holder = query.get_mut(self.player).unwrap();
-            let mut instance = instance_holder.instance.write();
+        as_system::<Query<&WorldHolder>>(self.ecs, |mut query| {
+            let world_holder = query.get_mut(self.player).unwrap();
+            let mut world = world_holder.shared.write();
 
             // add the new registry data
-            instance
+            world
                 .registries
                 .append(p.registry_id.clone(), p.entries.clone());
         });

--- a/azalea-client/src/plugins/packet/game/events.rs
+++ b/azalea-client/src/plugins/packet/game/events.rs
@@ -5,8 +5,7 @@ use azalea_protocol::packets::{
     Packet,
     game::{ClientboundGamePacket, ClientboundPlayerCombatKill, ServerboundGamePacket},
 };
-use azalea_registry::identifier::Identifier;
-use azalea_world::Instance;
+use azalea_world::{World, WorldName};
 use bevy_ecs::prelude::*;
 use parking_lot::RwLock;
 use tracing::{error, trace};
@@ -138,16 +137,18 @@ pub struct ResourcePackEvent {
     pub prompt: Option<FormattedText>,
 }
 
-/// An instance (aka world, dimension) was loaded by a client.
+/// A world instance (aka dimension) was loaded by a client.
 ///
-/// Since the instance is given to you as a weak reference, it won't be able to
-/// be `upgrade`d if all local players leave it.
+/// Since the world is given to you as a weak reference, it won't be able to be
+/// `upgrade`d if all local players unload it.
 #[derive(Clone, Debug, Message)]
-pub struct InstanceLoadedEvent {
+pub struct WorldLoadedEvent {
     pub entity: Entity,
-    pub name: Identifier,
-    pub instance: Weak<RwLock<Instance>>,
+    pub name: WorldName,
+    pub world: Weak<RwLock<World>>,
 }
+#[deprecated = "renamed to `WorldLoadedEvent`."]
+pub type InstanceLoadedEvent = WorldLoadedEvent;
 
 /// A Bevy trigger that's sent when our client receives a [`ClientboundPing`]
 /// packet in the game state.

--- a/azalea-client/src/plugins/packet/mod.rs
+++ b/azalea-client/src/plugins/packet/mod.rs
@@ -45,7 +45,7 @@ impl Plugin for PacketPlugin {
             .add_message::<game::DeathEvent>()
             .add_message::<game::KeepAliveEvent>()
             .add_message::<game::ResourcePackEvent>()
-            .add_message::<game::InstanceLoadedEvent>()
+            .add_message::<game::WorldLoadedEvent>()
             .add_message::<login::ReceiveCustomQueryEvent>();
     }
 }

--- a/azalea-client/src/plugins/tick_counter.rs
+++ b/azalea-client/src/plugins/tick_counter.rs
@@ -1,6 +1,6 @@
 use azalea_core::tick::GameTick;
 use azalea_physics::PhysicsSystems;
-use azalea_world::InstanceName;
+use azalea_world::WorldName;
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
 
@@ -27,9 +27,9 @@ impl Plugin for TickCounterPlugin {
     }
 }
 
-/// Increment the [`TicksConnected`] component on every entity
-/// that lives in an instance.
-pub fn increment_counter(mut query: Query<&mut TicksConnected, With<InstanceName>>) {
+/// Increment the [`TicksConnected`] component for every entity that's in any
+/// world.
+pub fn increment_counter(mut query: Query<&mut TicksConnected, With<WorldName>>) {
     for mut counter in &mut query {
         counter.0 += 1;
     }

--- a/azalea-client/src/plugins/tick_end.rs
+++ b/azalea-client/src/plugins/tick_end.rs
@@ -4,7 +4,7 @@ use azalea_core::tick::GameTick;
 use azalea_entity::LocalEntity;
 use azalea_physics::PhysicsSystems;
 use azalea_protocol::packets::game::ServerboundClientTickEnd;
-use azalea_world::InstanceName;
+use azalea_world::WorldName;
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
 
@@ -27,7 +27,7 @@ impl Plugin for TickEndPlugin {
 }
 
 pub fn game_tick_packet(
-    query: Query<Entity, (With<LocalEntity>, With<InstanceName>)>,
+    query: Query<Entity, (With<LocalEntity>, With<WorldName>)>,
     mut commands: Commands,
 ) {
     for entity in query.iter() {

--- a/azalea-client/src/test_utils/simulation.rs
+++ b/azalea-client/src/test_utils/simulation.rs
@@ -31,7 +31,7 @@ use azalea_registry::{
     data::{Biome, DimensionKind},
     identifier::Identifier,
 };
-use azalea_world::{Chunk, Instance, Section, palette::PalettedContainer};
+use azalea_world::{Chunk, Section, World, palette::PalettedContainer};
 use bevy_app::App;
 use bevy_ecs::{
     component::Mutable,
@@ -45,7 +45,7 @@ use uuid::Uuid;
 
 use crate::{
     InConfigState, LocalPlayerBundle, connection::RawConnection, disconnect::DisconnectEvent,
-    local_player::InstanceHolder, packet::game::SendGamePacketEvent, player::GameProfileComponent,
+    local_player::WorldHolder, packet::game::SendGamePacketEvent, player::GameProfileComponent,
 };
 
 /// A way to simulate a client in a server, used for some internal tests.
@@ -175,15 +175,15 @@ impl Simulation {
     }
 
     pub fn chunk(&self, chunk_pos: ChunkPos) -> Option<Arc<RwLock<Chunk>>> {
-        self.component::<InstanceHolder>()
-            .instance
+        self.component::<WorldHolder>()
+            .shared
             .read()
             .chunks
             .get(&chunk_pos)
     }
     pub fn get_block_state(&self, pos: BlockPos) -> Option<BlockState> {
-        self.component::<InstanceHolder>()
-            .instance
+        self.component::<WorldHolder>()
+            .shared
             .read()
             .get_block_state(pos)
     }
@@ -287,12 +287,12 @@ fn create_local_player_bundle(
 
     let raw_connection = RawConnection::new_networkless(connection_protocol);
 
-    let instance = Instance::default();
-    let instance_holder = InstanceHolder::new(entity, Arc::new(RwLock::new(instance)));
+    let world = World::default();
+    let world_holder = WorldHolder::new(entity, Arc::new(RwLock::new(world)));
 
     let local_player_bundle = LocalPlayerBundle {
         raw_connection,
-        instance_holder,
+        world_holder,
         metadata: PlayerMetadataBundle::default(),
     };
 

--- a/azalea-client/tests/simulation/change_dimension_to_nether_and_back.rs
+++ b/azalea-client/tests/simulation/change_dimension_to_nether_and_back.rs
@@ -6,7 +6,7 @@ use azalea_protocol::packets::{
     config::{ClientboundFinishConfiguration, ClientboundRegistryData},
 };
 use azalea_registry::{DataRegistry, data::DimensionKind, identifier::Identifier};
-use azalea_world::InstanceName;
+use azalea_world::WorldName;
 use simdnbt::owned::{NbtCompound, NbtTag};
 
 #[test]
@@ -19,12 +19,12 @@ fn test_change_dimension_to_nether_and_back() {
 
 fn generic_test_change_dimension_to_nether_and_back(using_respawn: bool) {
     let make_basic_login_or_respawn_packet = if using_respawn {
-        |dimension: DimensionKind, instance_name: Identifier| {
-            make_basic_respawn_packet(dimension, instance_name).into_variant()
+        |dimension: DimensionKind, world_name: Identifier| {
+            make_basic_respawn_packet(dimension, world_name).into_variant()
         }
     } else {
-        |dimension: DimensionKind, instance_name: Identifier| {
-            make_basic_login_packet(dimension, instance_name).into_variant()
+        |dimension: DimensionKind, world_name: Identifier| {
+            make_basic_login_packet(dimension, world_name).into_variant()
         }
     };
 
@@ -81,9 +81,9 @@ fn generic_test_change_dimension_to_nether_and_back(using_respawn: bool) {
     simulation.tick();
 
     assert_eq!(
-        *simulation.component::<InstanceName>(),
+        *simulation.component::<WorldName>(),
         Identifier::new("azalea:a"),
-        "InstanceName should be azalea:a after setting dimension to that"
+        "WorldName should be azalea:a after setting dimension to that"
     );
 
     simulation.receive_packet(make_basic_empty_chunk(ChunkPos::new(0, 0), (384 + 64) / 16));
@@ -108,9 +108,9 @@ fn generic_test_change_dimension_to_nether_and_back(using_respawn: bool) {
         "chunk should not exist immediately after changing dimensions"
     );
     assert_eq!(
-        *simulation.component::<InstanceName>(),
+        *simulation.component::<WorldName>(),
         Identifier::new("azalea:b"),
-        "InstanceName should be azalea:b after changing dimensions to that"
+        "WorldName should be azalea:b after changing dimensions to that"
     );
 
     simulation.receive_packet(make_basic_empty_chunk(ChunkPos::new(0, 0), 256 / 16));
@@ -136,9 +136,9 @@ fn generic_test_change_dimension_to_nether_and_back(using_respawn: bool) {
     simulation.tick();
 
     assert_eq!(
-        *simulation.component::<InstanceName>(),
+        *simulation.component::<WorldName>(),
         Identifier::new("azalea:a"),
-        "InstanceName should be azalea:a after setting dimension back to that"
+        "WorldName should be azalea:a after setting dimension back to that"
     );
     assert!(
         simulation.chunk(ChunkPos::new(0, 0)).is_none(),

--- a/azalea-client/tests/simulation/client_disconnect.rs
+++ b/azalea-client/tests/simulation/client_disconnect.rs
@@ -1,6 +1,6 @@
 use azalea_client::test_utils::prelude::*;
 use azalea_protocol::packets::ConnectionProtocol;
-use azalea_world::InstanceName;
+use azalea_world::WorldName;
 
 #[test]
 fn test_client_disconnect() {
@@ -12,7 +12,7 @@ fn test_client_disconnect() {
     simulation.tick();
 
     // make sure we're disconnected
-    let is_connected = simulation.has_component::<InstanceName>();
+    let is_connected = simulation.has_component::<WorldName>();
     assert!(!is_connected);
 
     // tick again to make sure nothing goes wrong

--- a/azalea-client/tests/simulation/login_to_dimension_with_same_name.rs
+++ b/azalea-client/tests/simulation/login_to_dimension_with_same_name.rs
@@ -1,5 +1,5 @@
 use azalea_client::{
-    InConfigState, InGameState, local_player::InstanceHolder, test_utils::prelude::*,
+    InConfigState, InGameState, local_player::WorldHolder, test_utils::prelude::*,
 };
 use azalea_core::position::ChunkPos;
 use azalea_entity::LocalEntity;
@@ -9,7 +9,7 @@ use azalea_protocol::packets::{
     game::ClientboundStartConfiguration,
 };
 use azalea_registry::{DataRegistry, data::DimensionKind, identifier::Identifier};
-use azalea_world::InstanceName;
+use azalea_world::WorldName;
 use simdnbt::owned::{NbtCompound, NbtTag};
 
 #[test]
@@ -22,12 +22,12 @@ fn test_login_to_dimension_with_same_name() {
 
 fn generic_test_login_to_dimension_with_same_name(using_respawn: bool) {
     let make_basic_login_or_respawn_packet = if using_respawn {
-        |dimension: DimensionKind, instance_name: Identifier| {
-            make_basic_respawn_packet(dimension, instance_name).into_variant()
+        |dimension: DimensionKind, world_name: Identifier| {
+            make_basic_respawn_packet(dimension, world_name).into_variant()
         }
     } else {
-        |dimension: DimensionKind, instance_name: Identifier| {
-            make_basic_login_packet(dimension, instance_name).into_variant()
+        |dimension: DimensionKind, world_name: Identifier| {
+            make_basic_login_packet(dimension, world_name).into_variant()
         }
     };
 
@@ -66,9 +66,9 @@ fn generic_test_login_to_dimension_with_same_name(using_respawn: bool) {
     simulation.tick();
 
     assert_eq!(
-        *simulation.component::<InstanceName>(),
+        *simulation.component::<WorldName>(),
         Identifier::new("azalea:overworld"),
-        "InstanceName should be azalea:overworld after setting dimension to that"
+        "WorldName should be azalea:overworld after setting dimension to that"
     );
 
     simulation.receive_packet(make_basic_empty_chunk(ChunkPos::new(0, 0), (384 + 64) / 16));
@@ -107,14 +107,14 @@ fn generic_test_login_to_dimension_with_same_name(using_respawn: bool) {
         "chunk should not exist immediately after changing dimensions"
     );
     assert_eq!(
-        *simulation.component::<InstanceName>(),
+        *simulation.component::<WorldName>(),
         Identifier::new("azalea:overworld"),
-        "InstanceName should still be azalea:overworld after changing dimensions to that"
+        "WorldName should still be azalea:overworld after changing dimensions to that"
     );
     assert_eq!(
         simulation
-            .component::<InstanceHolder>()
-            .instance
+            .component::<WorldHolder>()
+            .shared
             .read()
             .chunks
             .height,

--- a/azalea-client/tests/simulation/receive_spawn_entity_and_start_config_packet.rs
+++ b/azalea-client/tests/simulation/receive_spawn_entity_and_start_config_packet.rs
@@ -5,7 +5,7 @@ use azalea_protocol::packets::{
     game::{ClientboundAddEntity, ClientboundStartConfiguration},
 };
 use azalea_registry::builtin::EntityKind;
-use azalea_world::InstanceName;
+use azalea_world::WorldName;
 use uuid::Uuid;
 
 #[test]
@@ -15,7 +15,7 @@ fn test_receive_spawn_entity_and_start_config_packet() {
     let mut simulation = Simulation::new(ConnectionProtocol::Game);
     simulation.receive_packet(default_login_packet());
     simulation.tick();
-    assert!(simulation.has_component::<InstanceName>());
+    assert!(simulation.has_component::<WorldName>());
     simulation.tick();
 
     simulation.receive_packet(ClientboundAddEntity {

--- a/azalea-client/tests/simulation/receive_start_config_packet.rs
+++ b/azalea-client/tests/simulation/receive_start_config_packet.rs
@@ -1,6 +1,6 @@
 use azalea_client::{InConfigState, test_utils::prelude::*};
 use azalea_protocol::packets::{ConnectionProtocol, game::ClientboundStartConfiguration};
-use azalea_world::InstanceName;
+use azalea_world::WorldName;
 
 #[test]
 fn test_receive_start_config_packet() {
@@ -10,7 +10,7 @@ fn test_receive_start_config_packet() {
 
     simulation.receive_packet(default_login_packet());
     simulation.tick();
-    assert!(simulation.has_component::<InstanceName>());
+    assert!(simulation.has_component::<WorldName>());
     simulation.tick();
 
     simulation.receive_packet(ClientboundStartConfiguration);

--- a/azalea-core/src/registry_holder/mod.rs
+++ b/azalea-core/src/registry_holder/mod.rs
@@ -26,7 +26,7 @@ use tracing::error;
 ///
 /// This is the registry that is sent to the client upon login.
 ///
-/// Note that `azalea-client` stores registries in `Instance` rather than
+/// Note that `azalea-client` stores registries per-world rather than
 /// per-client like you might expect. This is an optimization for swarms to
 /// reduce memory usage, since registries are expected to be the same for every
 /// client in a world.

--- a/azalea-entity/src/plugin/components.rs
+++ b/azalea-entity/src/plugin/components.rs
@@ -1,7 +1,7 @@
 use azalea_block::fluid_state::FluidKind;
 use azalea_core::position::{BlockPos, ChunkPos, Vec3};
-use azalea_registry::{builtin::EntityKind, identifier::Identifier};
-use azalea_world::InstanceName;
+use azalea_registry::builtin::EntityKind;
+use azalea_world::WorldName;
 use bevy_ecs::{bundle::Bundle, component::Component};
 use derive_more::{Deref, DerefMut};
 use uuid::Uuid;
@@ -18,7 +18,7 @@ use crate::{
 pub struct EntityBundle {
     pub kind: EntityKindComponent,
     pub uuid: EntityUuid,
-    pub world_name: InstanceName,
+    pub world_name: WorldName,
     pub position: Position,
     pub last_sent_position: LastSentPosition,
 
@@ -36,13 +36,13 @@ pub struct EntityBundle {
 }
 
 impl EntityBundle {
-    pub fn new(uuid: Uuid, pos: Vec3, kind: EntityKind, world_name: Identifier) -> Self {
+    pub fn new(uuid: Uuid, pos: Vec3, kind: EntityKind, world_name: WorldName) -> Self {
         let dimensions = EntityDimensions::from(kind);
 
         Self {
             kind: EntityKindComponent(kind),
             uuid: EntityUuid(uuid),
-            world_name: InstanceName(world_name),
+            world_name,
             position: Position(pos),
             chunk_pos: EntityChunkPos(ChunkPos::from(&pos)),
             last_sent_position: LastSentPosition(pos),

--- a/azalea-entity/src/plugin/indexing.rs
+++ b/azalea-entity/src/plugin/indexing.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use azalea_core::{entity_id::MinecraftEntityId, position::ChunkPos};
-use azalea_world::{Instance, InstanceContainer, InstanceName};
+use azalea_world::{World, WorldName, Worlds};
 use bevy_ecs::prelude::*;
 use derive_more::{Deref, DerefMut};
 use nohash_hasher::IntMap;
@@ -48,10 +48,10 @@ impl EntityUuidIndex {
 /// An index of Minecraft entity IDs to Azalea ECS entities.
 ///
 /// This is a `Component` so local players can keep track of entity IDs
-/// independently from the instance.
+/// independently from the world.
 ///
-/// If you need a per-instance instead of per-client version of this, you can
-/// use [`Instance::entity_by_id`].
+/// If you need a per-world instead of per-client version of this, you can
+/// use [`World::entity_by_id`].
 #[derive(Component, Default)]
 pub struct EntityIdIndex {
     /// An index of entities by their MinecraftEntityId
@@ -105,7 +105,7 @@ impl EntityIdIndex {
         } else {
             // this is expected to happen when despawning entities if it was already
             // despawned for another reason (like because the client received a
-            // remove_entities packet, or if we're in a shared instance where entity ids are
+            // remove_entities packet, or if we're in a shared world where entity ids are
             // different for each client)
             trace!(
                 "Failed to remove {entity:?} from a client's EntityIdIndex (using EntityIdIndex::remove_by_ecs_entity). This may be expected behavior."
@@ -125,30 +125,30 @@ impl Debug for EntityUuidIndex {
 #[derive(Component, Debug, Deref, DerefMut)]
 pub struct EntityChunkPos(pub ChunkPos);
 
-/// Update the chunk position indexes in [`Instance::entities_by_chunk`].
+/// Update the chunk position indexes in [`World::entities_by_chunk`].
 ///
-/// [`Instance::entities_by_chunk`]: azalea_world::Instance::entities_by_chunk
+/// [`World::entities_by_chunk`]: azalea_world::World::entities_by_chunk
 pub fn update_entity_chunk_positions(
-    mut query: Query<(Entity, &Position, &InstanceName, &mut EntityChunkPos), Changed<Position>>,
-    instance_container: Res<InstanceContainer>,
+    mut query: Query<(Entity, &Position, &WorldName, &mut EntityChunkPos), Changed<Position>>,
+    worlds: Res<Worlds>,
 ) {
-    for (entity, pos, instance_name, mut entity_chunk_pos) in query.iter_mut() {
+    for (entity, pos, world_name, mut entity_chunk_pos) in query.iter_mut() {
         let old_chunk = **entity_chunk_pos;
         let new_chunk = ChunkPos::from(*pos);
         if old_chunk != new_chunk {
             **entity_chunk_pos = new_chunk;
 
             if old_chunk != new_chunk {
-                let Some(instance_lock) = instance_container.get(instance_name) else {
+                let Some(world_lock) = worlds.get(world_name) else {
                     continue;
                 };
-                let mut instance = instance_lock.write();
+                let mut world = world_lock.write();
 
                 // move the entity from the old chunk to the new one
-                if let Some(entities) = instance.entities_by_chunk.get_mut(&old_chunk) {
+                if let Some(entities) = world.entities_by_chunk.get_mut(&old_chunk) {
                     entities.remove(&entity);
                 }
-                instance
+                world
                     .entities_by_chunk
                     .entry(new_chunk)
                     .or_default()
@@ -159,20 +159,20 @@ pub fn update_entity_chunk_positions(
     }
 }
 
-/// Insert new entities into [`Instance::entities_by_chunk`].
+/// Insert new entities into [`World::entities_by_chunk`].
 pub fn insert_entity_chunk_position(
-    query: Query<(Entity, &Position, &InstanceName), Added<EntityChunkPos>>,
-    instance_container: Res<InstanceContainer>,
+    query: Query<(Entity, &Position, &WorldName), Added<EntityChunkPos>>,
+    worlds: Res<Worlds>,
 ) {
     for (entity, pos, world_name) in query.iter() {
-        let Some(instance_lock) = instance_container.get(world_name) else {
+        let Some(world_lock) = worlds.get(world_name) else {
             // entity must've been despawned already
             continue;
         };
-        let mut instance = instance_lock.write();
+        let mut world = world_lock.write();
 
         let chunk = ChunkPos::from(*pos);
-        instance
+        world
             .entities_by_chunk
             .entry(chunk)
             .or_default()
@@ -185,26 +185,24 @@ pub fn insert_entity_chunk_position(
 pub fn remove_despawned_entities_from_indexes(
     mut commands: Commands,
     mut entity_uuid_index: ResMut<EntityUuidIndex>,
-    instance_container: Res<InstanceContainer>,
+    worlds: Res<Worlds>,
     query: Query<
         (
             Entity,
             &EntityUuid,
             &MinecraftEntityId,
             &Position,
-            &InstanceName,
+            &WorldName,
             &LoadedBy,
         ),
         (Changed<LoadedBy>, Without<LocalEntity>),
     >,
     mut entity_id_index_query: Query<&mut EntityIdIndex>,
 ) {
-    for (entity, uuid, minecraft_id, position, instance_name, loaded_by) in &query {
-        let Some(instance_lock) = instance_container.get(instance_name) else {
-            // the instance isn't even loaded by us, so we can safely delete the entity
-            debug!(
-                "Despawned entity {entity:?} because it's in an instance that isn't loaded anymore"
-            );
+    for (entity, uuid, minecraft_id, position, world_name, loaded_by) in &query {
+        let Some(world_lock) = worlds.get(world_name) else {
+            // the world isn't even loaded by us, so we can safely delete the entity
+            debug!("Despawned entity {entity:?} because it's in a world that isn't loaded anymore");
             if entity_uuid_index.entity_by_uuid.remove(uuid).is_none() {
                 warn!(
                     "Tried to remove entity {entity:?} from the uuid index but it was not there."
@@ -216,7 +214,7 @@ pub fn remove_despawned_entities_from_indexes(
             continue;
         };
 
-        let mut instance = instance_lock.write();
+        let mut world = world_lock.write();
 
         // if the entity is being loaded by any of our clients, don't despawn it
         if !loaded_by.is_empty() {
@@ -225,17 +223,17 @@ pub fn remove_despawned_entities_from_indexes(
 
         // remove the entity from the chunk index
         let chunk = ChunkPos::from(position);
-        match instance.entities_by_chunk.get_mut(&chunk) {
+        match world.entities_by_chunk.get_mut(&chunk) {
             Some(entities_in_chunk) => {
                 if entities_in_chunk.remove(&entity) {
                     // remove the chunk if there's no entities in it anymore
                     if entities_in_chunk.is_empty() {
-                        instance.entities_by_chunk.remove(&chunk);
+                        world.entities_by_chunk.remove(&chunk);
                     }
                 } else {
                     // search all the other chunks for it :(
                     let mut found_in_other_chunks = HashSet::new();
-                    for (other_chunk, entities_in_other_chunk) in &mut instance.entities_by_chunk {
+                    for (other_chunk, entities_in_other_chunk) in &mut world.entities_by_chunk {
                         if entities_in_other_chunk.remove(&entity) {
                             found_in_other_chunks.insert(other_chunk);
                         }
@@ -253,7 +251,7 @@ pub fn remove_despawned_entities_from_indexes(
             }
             _ => {
                 let mut found_in_other_chunks = HashSet::new();
-                for (other_chunk, entities_in_other_chunk) in &mut instance.entities_by_chunk {
+                for (other_chunk, entities_in_other_chunk) in &mut world.entities_by_chunk {
                     if entities_in_other_chunk.remove(&entity) {
                         found_in_other_chunks.insert(other_chunk);
                     }
@@ -273,9 +271,9 @@ pub fn remove_despawned_entities_from_indexes(
         if entity_uuid_index.entity_by_uuid.remove(uuid).is_none() {
             warn!("Tried to remove entity {entity:?} from the uuid index but it was not there.");
         }
-        if instance.entity_by_id.remove(minecraft_id).is_none() {
+        if world.entity_by_id.remove(minecraft_id).is_none() {
             debug!(
-                "Tried to remove entity {entity:?} from the per-instance entity id index but it was not there. This may be expected if you're in a shared instance."
+                "Tried to remove entity {entity:?} from the per-world entity id index but it was not there. This may be expected if you're in a shared world."
             );
         }
 
@@ -296,16 +294,16 @@ pub fn add_entity_to_indexes(
     entity_uuid: Option<Uuid>,
     entity_id_index: &mut EntityIdIndex,
     entity_uuid_index: &mut EntityUuidIndex,
-    instance: &mut Instance,
+    world: &mut World,
 ) {
     // per-client id index
     entity_id_index.insert(entity_id, ecs_entity);
 
-    // per-instance id index
-    instance.entity_by_id.insert(entity_id, ecs_entity);
+    // per-world id index
+    world.entity_by_id.insert(entity_id, ecs_entity);
 
     if let Some(uuid) = entity_uuid {
-        // per-instance uuid index
+        // per-world uuid index
         entity_uuid_index.insert(uuid, ecs_entity);
     }
 }

--- a/azalea-entity/src/plugin/mod.rs
+++ b/azalea-entity/src/plugin/mod.rs
@@ -11,7 +11,7 @@ use azalea_core::{
     tick::GameTick,
 };
 use azalea_registry::{builtin::BlockKind, tags};
-use azalea_world::{ChunkStorage, InstanceContainer, InstanceName};
+use azalea_world::{ChunkStorage, WorldName, Worlds};
 use bevy_app::{App, Plugin, PostUpdate, Update};
 use bevy_ecs::prelude::*;
 pub use components::*;
@@ -97,22 +97,17 @@ pub fn add_dead(mut commands: Commands, query: Query<(Entity, &Health), Changed<
 }
 
 pub fn update_fluid_on_eyes(
-    mut query: Query<(
-        &mut FluidOnEyes,
-        &Position,
-        &EntityDimensions,
-        &InstanceName,
-    )>,
-    instance_container: Res<InstanceContainer>,
+    mut query: Query<(&mut FluidOnEyes, &Position, &EntityDimensions, &WorldName)>,
+    worlds: Res<Worlds>,
 ) {
-    for (mut fluid_on_eyes, position, dimensions, instance_name) in query.iter_mut() {
-        let Some(instance) = instance_container.get(instance_name) else {
+    for (mut fluid_on_eyes, position, dimensions, world_name) in query.iter_mut() {
+        let Some(world) = worlds.get(world_name) else {
             continue;
         };
 
         let adjusted_eye_y = position.y + (dimensions.eye_height as f64) - 0.1111111119389534;
         let eye_block_pos = BlockPos::from(position.with_y(adjusted_eye_y));
-        let fluid_at_eye = instance
+        let fluid_at_eye = world
             .read()
             .get_fluid_state(eye_block_pos)
             .unwrap_or_default();
@@ -126,10 +121,10 @@ pub fn update_fluid_on_eyes(
 }
 
 pub fn update_on_climbable(
-    mut query: Query<(&mut OnClimbable, &Position, &InstanceName), With<LocalEntity>>,
-    instance_container: Res<InstanceContainer>,
+    mut query: Query<(&mut OnClimbable, &Position, &WorldName), With<LocalEntity>>,
+    worlds: Res<Worlds>,
 ) {
-    for (mut on_climbable, position, instance_name) in query.iter_mut() {
+    for (mut on_climbable, position, world_name) in query.iter_mut() {
         // TODO: there's currently no gamemode component that can be accessed from here,
         // maybe LocalGameMode should be replaced with two components, maybe called
         // EntityGameMode and PreviousGameMode?
@@ -138,27 +133,27 @@ pub fn update_on_climbable(
         //     continue;
         // }
 
-        let Some(instance) = instance_container.get(instance_name) else {
+        let Some(world) = worlds.get(world_name) else {
             continue;
         };
 
-        let instance = instance.read();
+        let world = world.read();
 
         let block_pos = BlockPos::from(position);
-        let block_state_at_feet = instance.get_block_state(block_pos).unwrap_or_default();
+        let block_state_at_feet = world.get_block_state(block_pos).unwrap_or_default();
         let block_at_feet = Box::<dyn BlockTrait>::from(block_state_at_feet);
         let registry_block_at_feet = block_at_feet.as_registry_block();
 
         **on_climbable = tags::blocks::CLIMBABLE.contains(&registry_block_at_feet)
             || (tags::blocks::TRAPDOORS.contains(&registry_block_at_feet)
-                && is_trapdoor_useable_as_ladder(block_state_at_feet, block_pos, &instance));
+                && is_trapdoor_usable_as_ladder(block_state_at_feet, block_pos, &world));
     }
 }
 
-fn is_trapdoor_useable_as_ladder(
+fn is_trapdoor_usable_as_ladder(
     block_state: BlockState,
     block_pos: BlockPos,
-    instance: &azalea_world::Instance,
+    world: &azalea_world::World,
 ) -> bool {
     // trapdoor must be open
     if !block_state
@@ -169,9 +164,7 @@ fn is_trapdoor_useable_as_ladder(
     }
 
     // block below must be a ladder
-    let block_below = instance
-        .get_block_state(block_pos.down(1))
-        .unwrap_or_default();
+    let block_below = world.get_block_state(block_pos.down(1)).unwrap_or_default();
     let registry_block_below = Box::<dyn BlockTrait>::from(block_below).as_registry_block();
     if registry_block_below != BlockKind::Ladder {
         return false;
@@ -257,17 +250,17 @@ pub struct InLoadedChunk;
 /// Update the [`InLoadedChunk`] component for all entities in the world.
 pub fn update_in_loaded_chunk(
     mut commands: bevy_ecs::system::Commands,
-    query: Query<(Entity, &InstanceName, &Position)>,
-    instance_container: Res<InstanceContainer>,
+    query: Query<(Entity, &WorldName, &Position)>,
+    worlds: Res<Worlds>,
 ) {
-    for (entity, instance_name, position) in &query {
+    for (entity, world_name, position) in &query {
         let player_chunk_pos = ChunkPos::from(position);
-        let Some(instance_lock) = instance_container.get(instance_name) else {
+        let Some(world_lock) = worlds.get(world_name) else {
             commands.entity(entity).remove::<InLoadedChunk>();
             continue;
         };
 
-        let in_loaded_chunk = instance_lock.read().chunks.get(&player_chunk_pos).is_some();
+        let in_loaded_chunk = world_lock.read().chunks.get(&player_chunk_pos).is_some();
         if in_loaded_chunk {
             commands.entity(entity).insert(InLoadedChunk);
         } else {
@@ -326,20 +319,20 @@ mod tests {
     };
     use azalea_core::position::{BlockPos, ChunkPos};
     use azalea_registry::builtin::BlockKind;
-    use azalea_world::{Chunk, ChunkStorage, Instance, PartialInstance};
+    use azalea_world::{Chunk, ChunkStorage, PartialWorld, World};
 
-    use super::is_trapdoor_useable_as_ladder;
+    use super::is_trapdoor_usable_as_ladder;
 
     #[test]
     fn test_is_trapdoor_useable_as_ladder() {
-        let mut partial_instance = PartialInstance::default();
+        let mut partial_world = PartialWorld::default();
         let mut chunks = ChunkStorage::default();
-        partial_instance.chunks.set(
+        partial_world.chunks.set(
             &ChunkPos { x: 0, z: 0 },
             Some(Chunk::default()),
             &mut chunks,
         );
-        partial_instance.chunks.set_block_state(
+        partial_world.chunks.set_block_state(
             BlockPos::new(0, 0, 0),
             BlockKind::Stone.into(),
             &chunks,
@@ -349,7 +342,7 @@ mod tests {
             facing: FacingCardinal::East,
             waterlogged: false,
         };
-        partial_instance
+        partial_world
             .chunks
             .set_block_state(BlockPos::new(0, 0, 0), ladder.into(), &chunks);
 
@@ -360,17 +353,17 @@ mod tests {
             powered: false,
             waterlogged: false,
         };
-        partial_instance
+        partial_world
             .chunks
             .set_block_state(BlockPos::new(0, 1, 0), trapdoor.into(), &chunks);
 
-        let instance = Instance::from(chunks);
-        let trapdoor_matches_ladder = is_trapdoor_useable_as_ladder(
-            instance
+        let world = World::from(chunks);
+        let trapdoor_matches_ladder = is_trapdoor_usable_as_ladder(
+            world
                 .get_block_state(BlockPos::new(0, 1, 0))
                 .unwrap_or_default(),
             BlockPos::new(0, 1, 0),
-            &instance,
+            &world,
         );
 
         assert!(trapdoor_matches_ladder);

--- a/azalea-entity/src/plugin/relative_updates.rs
+++ b/azalea-entity/src/plugin/relative_updates.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use azalea_core::entity_id::MinecraftEntityId;
-use azalea_world::PartialInstance;
+use azalea_world::PartialWorld;
 use bevy_ecs::prelude::*;
 use derive_more::{Deref, DerefMut};
 use parking_lot::RwLock;
@@ -38,13 +38,13 @@ use crate::LocalEntity;
 /// other clients within render distance will get too. You usually don't need
 /// this when the change isn't relative either.
 pub struct RelativeEntityUpdate {
-    pub partial_world: Arc<RwLock<PartialInstance>>,
+    pub partial_world: Arc<RwLock<PartialWorld>>,
     // a function that takes the entity and updates it
     pub update: Box<dyn FnOnce(&mut EntityWorldMut) + Send + Sync>,
 }
 impl RelativeEntityUpdate {
     pub fn new(
-        partial_world: Arc<RwLock<PartialInstance>>,
+        partial_world: Arc<RwLock<PartialWorld>>,
         update: impl FnOnce(&mut EntityWorldMut) + Send + Sync + 'static,
     ) -> Self {
         Self {

--- a/azalea-physics/src/collision/entity_collisions.rs
+++ b/azalea-physics/src/collision/entity_collisions.rs
@@ -3,7 +3,7 @@ use azalea_entity::{
     Physics,
     metadata::{AbstractBoat, Shulker},
 };
-use azalea_world::Instance;
+use azalea_world::World;
 use bevy_ecs::{
     component::Component,
     entity::Entity,
@@ -51,7 +51,7 @@ pub fn update_last_bounding_box(
 }
 
 pub fn get_entity_collisions(
-    world: &Instance,
+    world: &World,
     aabb: &Aabb,
     source_entity: Option<Entity>,
     aabb_query: &AabbQuery,
@@ -83,7 +83,7 @@ pub fn get_entity_collisions(
 /// `source_entity` is the entity that the bounding box belongs to, and won't be
 /// one of the returned entities.
 pub fn get_entities(
-    world: &Instance,
+    world: &World,
     source_entity: Option<Entity>,
     aabb: &Aabb,
     predicate: &dyn Fn(Entity) -> bool,

--- a/azalea-physics/src/collision/mod.rs
+++ b/azalea-physics/src/collision/mod.rs
@@ -19,7 +19,7 @@ use azalea_entity::{
     metadata::Sprinting,
 };
 use azalea_registry::builtin::BlockKind;
-use azalea_world::{ChunkStorage, Instance};
+use azalea_world::{ChunkStorage, World};
 use bevy_ecs::{entity::Entity, world::Mut};
 pub use blocks::BlockWithShape;
 pub use discrete_voxel_shape::*;
@@ -110,7 +110,7 @@ fn collide(ctx: &MoveCtx, movement: Vec3) -> Vec3 {
 
 pub struct MoveCtx<'world, 'state, 'a, 'b> {
     pub mover_type: MoverType,
-    pub world: &'a Instance,
+    pub world: &'a World,
     pub position: Mut<'a, Position>,
     pub physics: &'a mut Physics,
     pub source_entity: Entity,
@@ -338,7 +338,7 @@ fn is_above_ground(ctx: &CanFallAtLeastCtx, max_up_step: f32) -> bool {
 
 pub struct CanFallAtLeastCtx<'world, 'state, 'a, 'b> {
     physics: &'a Physics,
-    world: &'a Instance,
+    world: &'a World,
     source_entity: Entity,
     aabb_query: &'a AabbQuery<'world, 'state, 'b>,
     collidable_entity_query: &'a CollidableEntityQuery<'world, 'state>,
@@ -377,7 +377,7 @@ fn can_fall_at_least(
 fn collide_bounding_box(
     movement: Vec3,
     entity_bounding_box: &Aabb,
-    world: &Instance,
+    world: &World,
     entity_collisions: &[VoxelShape],
 ) -> Vec3 {
     let mut collision_boxes: Vec<VoxelShape> = Vec::with_capacity(entity_collisions.len() + 1);
@@ -437,7 +437,7 @@ fn collide_with_shapes(
 
 /// Get the [`VoxelShape`] for the given fluid state.
 ///
-/// The instance and position are required so it can check if the block above is
+/// The world and position are required so it can check if the block above is
 /// also the same fluid type.
 pub fn fluid_shape(fluid: &FluidState, world: &ChunkStorage, pos: BlockPos) -> &'static VoxelShape {
     if fluid.amount == 9 {

--- a/azalea-physics/src/collision/world_collisions.rs
+++ b/azalea-physics/src/collision/world_collisions.rs
@@ -7,14 +7,14 @@ use azalea_core::{
     position::{BlockPos, ChunkBlockPos, ChunkPos, ChunkSectionBlockPos, ChunkSectionPos, Vec3},
 };
 use azalea_inventory::ItemStack;
-use azalea_world::{Chunk, Instance};
+use azalea_world::{Chunk, World};
 use bevy_ecs::entity::Entity;
 use parking_lot::RwLock;
 
 use super::{BLOCK_SHAPE, Shapes};
 use crate::collision::{Aabb, BlockWithShape, VoxelShape};
 
-pub fn get_block_collisions(world: &Instance, aabb: &Aabb) -> Vec<VoxelShape> {
+pub fn get_block_collisions(world: &World, aabb: &Aabb) -> Vec<VoxelShape> {
     let mut state = BlockCollisionsState::new(world, aabb, EntityCollisionContext::of(None));
     let mut block_collisions = Vec::new();
 
@@ -34,7 +34,7 @@ pub fn get_block_collisions(world: &Instance, aabb: &Aabb) -> Vec<VoxelShape> {
     block_collisions
 }
 
-pub fn get_block_and_liquid_collisions(world: &Instance, aabb: &Aabb) -> Vec<VoxelShape> {
+pub fn get_block_and_liquid_collisions(world: &World, aabb: &Aabb) -> Vec<VoxelShape> {
     let mut state = BlockCollisionsState::new(
         world,
         aabb,
@@ -59,7 +59,7 @@ pub fn get_block_and_liquid_collisions(world: &Instance, aabb: &Aabb) -> Vec<Vox
 }
 
 pub struct BlockCollisionsState<'a> {
-    pub world: &'a Instance,
+    pub world: &'a World,
     pub aabb: &'a Aabb,
     pub entity_shape: VoxelShape,
     pub cursor: Cursor3d,
@@ -126,7 +126,7 @@ impl<'a> BlockCollisionsState<'a> {
         block_collisions.push(block_shape);
     }
 
-    pub fn new(world: &'a Instance, aabb: &'a Aabb, context: EntityCollisionContext) -> Self {
+    pub fn new(world: &'a World, aabb: &'a Aabb, context: EntityCollisionContext) -> Self {
         let origin = BlockPos {
             x: (aabb.min.x - EPSILON).floor() as i32 - 1,
             y: (aabb.min.y - EPSILON).floor() as i32 - 1,
@@ -283,7 +283,7 @@ impl CanStandOnFluidPredicate {
 /// a performance loss for Azalea. If this ever turns out to be a bottleneck,
 /// then maybe you should try having it do that instead.
 pub fn for_entities_in_chunks_colliding_with(
-    world: &Instance,
+    world: &World,
     aabb: &Aabb,
     mut consumer: impl FnMut(ChunkPos, &HashSet<Entity>),
 ) {

--- a/azalea-physics/src/fluids.rs
+++ b/azalea-physics/src/fluids.rs
@@ -8,7 +8,7 @@ use azalea_core::{
 };
 use azalea_entity::{HasClientLoaded, LocalEntity, Physics, Position};
 use azalea_registry::builtin::BlockKind;
-use azalea_world::{Instance, InstanceContainer, InstanceName};
+use azalea_world::{World, WorldName, Worlds};
 use bevy_ecs::prelude::*;
 
 use crate::collision::legacy_blocks_motion;
@@ -16,13 +16,13 @@ use crate::collision::legacy_blocks_motion;
 #[allow(clippy::type_complexity)]
 pub fn update_in_water_state_and_do_fluid_pushing(
     mut query: Query<
-        (&mut Physics, &Position, &InstanceName),
+        (&mut Physics, &Position, &WorldName),
         (With<LocalEntity>, With<HasClientLoaded>),
     >,
-    instance_container: Res<InstanceContainer>,
+    worlds: Res<Worlds>,
 ) {
-    for (mut physics, position, instance_name) in &mut query {
-        let Some(world_lock) = instance_container.get(instance_name) else {
+    for (mut physics, position, world_name) in &mut query {
+        let Some(world_lock) = worlds.get(world_name) else {
             continue;
         };
         let world = world_lock.read();
@@ -41,7 +41,7 @@ pub fn update_in_water_state_and_do_fluid_pushing(
             .registries
             .dimension_type
             .map
-            .get(&**instance_name)
+            .get(&**world_name)
             .and_then(|i| i.ultrawarm)
             .unwrap_or_default();
         let lava_push_factor = if is_ultrawarm {
@@ -60,7 +60,7 @@ pub fn update_in_water_state_and_do_fluid_pushing(
 }
 fn update_in_water_state_and_do_water_current_pushing(
     physics: &mut Physics,
-    world: &Instance,
+    world: &World,
     _position: Position,
 ) {
     // TODO: implement vehicles and boats
@@ -86,7 +86,7 @@ fn update_in_water_state_and_do_water_current_pushing(
 
 fn update_fluid_height_and_do_fluid_pushing(
     physics: &mut Physics,
-    world: &Instance,
+    world: &World,
     checking_fluid: FluidKind,
     fluid_push_factor: f64,
 ) -> bool {
@@ -180,7 +180,7 @@ pub fn update_swimming() {
 }
 
 // FlowingFluid.getFlow
-pub fn get_fluid_flow(fluid: &FluidState, world: &Instance, pos: BlockPos) -> Vec3 {
+pub fn get_fluid_flow(fluid: &FluidState, world: &World, pos: BlockPos) -> Vec3 {
     let mut z_flow: f64 = 0.;
     let mut x_flow: f64 = 0.;
 
@@ -244,7 +244,7 @@ pub fn get_fluid_flow(fluid: &FluidState, world: &Instance, pos: BlockPos) -> Ve
 // i don't really get what this is for
 fn is_solid_face(
     fluid: &FluidState,
-    world: &Instance,
+    world: &World,
     adjacent_pos: BlockPos,
     direction: Direction,
 ) -> bool {
@@ -269,7 +269,7 @@ fn is_solid_face(
 
 fn is_face_sturdy(
     _block_state: BlockState,
-    _world: &Instance,
+    _world: &World,
     _pos: BlockPos,
     _direction: Direction,
 ) -> bool {

--- a/azalea-physics/src/travel.rs
+++ b/azalea-physics/src/travel.rs
@@ -7,7 +7,7 @@ use azalea_entity::{
     Attributes, HasClientLoaded, Jumping, LocalEntity, LookDirection, OnClimbable, Physics,
     PlayerAbilities, Pose, Position, metadata::Sprinting, move_relative,
 };
-use azalea_world::{Instance, InstanceContainer, InstanceName};
+use azalea_world::{World, WorldName, Worlds};
 use bevy_ecs::prelude::*;
 
 use crate::{
@@ -29,7 +29,7 @@ pub fn travel(
         (
             Entity,
             &Attributes,
-            &InstanceName,
+            &WorldName,
             &OnClimbable,
             &Jumping,
             Option<&PhysicsState>,
@@ -42,7 +42,7 @@ pub fn travel(
         ),
         (With<LocalEntity>, With<HasClientLoaded>),
     >,
-    instance_container: Res<InstanceContainer>,
+    worlds: Res<Worlds>,
     aabb_query: AabbQuery,
     collidable_entity_query: CollidableEntityQuery,
 ) {
@@ -61,7 +61,7 @@ pub fn travel(
         position,
     ) in &mut query
     {
-        let Some(world_lock) = instance_container.get(world_name) else {
+        let Some(world_lock) = worlds.get(world_name) else {
             continue;
         };
         let world = world_lock.read();
@@ -252,7 +252,7 @@ fn get_fluid_falling_adjusted_movement(
 }
 
 fn is_free(
-    world: &Instance,
+    world: &World,
     source_entity: Entity,
     aabb_query: &AabbQuery,
     collidable_entity_query: &CollidableEntityQuery,
@@ -274,7 +274,7 @@ fn is_free(
 }
 
 pub fn no_collision(
-    world: &Instance,
+    world: &World,
     source_entity: Option<Entity>,
     aabb_query: &AabbQuery,
     collidable_entity_query: &CollidableEntityQuery,
@@ -323,7 +323,7 @@ fn border_collision(_entity_physics: &Physics, _aabb: &Aabb) -> Option<Aabb> {
     None
 }
 
-fn contains_any_liquid(world: &Instance, bounding_box: Aabb) -> bool {
+fn contains_any_liquid(world: &World, bounding_box: Aabb) -> bool {
     let min = bounding_box.min.to_block_pos_floor();
     let max = bounding_box.max.to_block_pos_ceil();
 

--- a/azalea-physics/tests/physics.rs
+++ b/azalea-physics/tests/physics.rs
@@ -12,11 +12,8 @@ use azalea_core::{
 };
 use azalea_entity::{EntityBundle, EntityPlugin, HasClientLoaded, LocalEntity, Physics, Position};
 use azalea_physics::PhysicsPlugin;
-use azalea_registry::{
-    builtin::{BlockKind, EntityKind},
-    identifier::Identifier,
-};
-use azalea_world::{Chunk, Instance, InstanceContainer, PartialInstance};
+use azalea_registry::builtin::{BlockKind, EntityKind};
+use azalea_world::{Chunk, PartialWorld, World, WorldName, Worlds};
 use bevy_app::App;
 use parking_lot::RwLock;
 use uuid::Uuid;
@@ -25,26 +22,24 @@ use uuid::Uuid;
 fn make_test_app() -> App {
     let mut app = App::new();
     app.add_plugins((PhysicsPlugin, EntityPlugin))
-        .init_resource::<InstanceContainer>();
+        .init_resource::<Worlds>();
     app
 }
 
-pub fn insert_overworld(app: &mut App) -> Arc<RwLock<Instance>> {
-    app.world_mut()
-        .resource_mut::<InstanceContainer>()
-        .get_or_insert(
-            Identifier::new("minecraft:overworld"),
-            384,
-            -64,
-            &RegistryHolder::default(),
-        )
+pub fn insert_overworld(app: &mut App) -> Arc<RwLock<World>> {
+    app.world_mut().resource_mut::<Worlds>().get_or_insert(
+        WorldName::new("minecraft:overworld"),
+        384,
+        -64,
+        &RegistryHolder::default(),
+    )
 }
 
 #[test]
 fn test_gravity() {
     let mut app = make_test_app();
     let world_lock = insert_overworld(&mut app);
-    let mut partial_world = PartialInstance::default();
+    let mut partial_world = PartialWorld::default();
     // the entity has to be in a loaded chunk for physics to work
     partial_world.chunks.set(
         &ChunkPos { x: 0, z: 0 },
@@ -63,7 +58,7 @@ fn test_gravity() {
                     z: 0.,
                 },
                 EntityKind::Zombie,
-                Identifier::new("minecraft:overworld"),
+                WorldName::new("minecraft:overworld"),
             ),
             MinecraftEntityId(0),
             LocalEntity,
@@ -101,7 +96,7 @@ fn test_gravity() {
 fn test_collision() {
     let mut app = make_test_app();
     let world_lock = insert_overworld(&mut app);
-    let mut partial_world = PartialInstance::default();
+    let mut partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: 0, z: 0 },
@@ -119,7 +114,7 @@ fn test_collision() {
                     z: 0.5,
                 },
                 EntityKind::Player,
-                Identifier::new("minecraft:overworld"),
+                WorldName::new("minecraft:overworld"),
             ),
             MinecraftEntityId(0),
             LocalEntity,
@@ -158,7 +153,7 @@ fn test_collision() {
 fn test_slab_collision() {
     let mut app = make_test_app();
     let world_lock = insert_overworld(&mut app);
-    let mut partial_world = PartialInstance::default();
+    let mut partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: 0, z: 0 },
@@ -176,7 +171,7 @@ fn test_slab_collision() {
                     z: 0.5,
                 },
                 EntityKind::Player,
-                Identifier::new("minecraft:overworld"),
+                WorldName::new("minecraft:overworld"),
             ),
             MinecraftEntityId(0),
             LocalEntity,
@@ -209,7 +204,7 @@ fn test_slab_collision() {
 fn test_top_slab_collision() {
     let mut app = make_test_app();
     let world_lock = insert_overworld(&mut app);
-    let mut partial_world = PartialInstance::default();
+    let mut partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: 0, z: 0 },
@@ -227,7 +222,7 @@ fn test_top_slab_collision() {
                     z: 0.5,
                 },
                 EntityKind::Player,
-                Identifier::new("minecraft:overworld"),
+                WorldName::new("minecraft:overworld"),
             ),
             MinecraftEntityId(0),
             LocalEntity,
@@ -258,16 +253,13 @@ fn test_top_slab_collision() {
 #[test]
 fn test_weird_wall_collision() {
     let mut app = make_test_app();
-    let world_lock = app
-        .world_mut()
-        .resource_mut::<InstanceContainer>()
-        .get_or_insert(
-            Identifier::new("minecraft:overworld"),
-            384,
-            -64,
-            &RegistryHolder::default(),
-        );
-    let mut partial_world = PartialInstance::default();
+    let world_lock = app.world_mut().resource_mut::<Worlds>().get_or_insert(
+        WorldName::new("minecraft:overworld"),
+        384,
+        -64,
+        &RegistryHolder::default(),
+    );
+    let mut partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: 0, z: 0 },
@@ -285,7 +277,7 @@ fn test_weird_wall_collision() {
                     z: 0.5,
                 },
                 EntityKind::Player,
-                Identifier::new("minecraft:overworld"),
+                WorldName::new("minecraft:overworld"),
             ),
             MinecraftEntityId(0),
             LocalEntity,
@@ -321,16 +313,13 @@ fn test_weird_wall_collision() {
 #[test]
 fn test_negative_coordinates_weird_wall_collision() {
     let mut app = make_test_app();
-    let world_lock = app
-        .world_mut()
-        .resource_mut::<InstanceContainer>()
-        .get_or_insert(
-            Identifier::new("minecraft:overworld"),
-            384,
-            -64,
-            &RegistryHolder::default(),
-        );
-    let mut partial_world = PartialInstance::default();
+    let world_lock = app.world_mut().resource_mut::<Worlds>().get_or_insert(
+        WorldName::new("minecraft:overworld"),
+        384,
+        -64,
+        &RegistryHolder::default(),
+    );
+    let mut partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: -1, z: -1 },
@@ -348,7 +337,7 @@ fn test_negative_coordinates_weird_wall_collision() {
                     z: -7.5,
                 },
                 EntityKind::Player,
-                Identifier::new("minecraft:overworld"),
+                WorldName::new("minecraft:overworld"),
             ),
             MinecraftEntityId(0),
             LocalEntity,
@@ -388,16 +377,13 @@ fn test_negative_coordinates_weird_wall_collision() {
 #[test]
 fn spawn_and_unload_world() {
     let mut app = make_test_app();
-    let world_lock = app
-        .world_mut()
-        .resource_mut::<InstanceContainer>()
-        .get_or_insert(
-            Identifier::new("minecraft:overworld"),
-            384,
-            -64,
-            &RegistryHolder::default(),
-        );
-    let mut partial_world = PartialInstance::default();
+    let world_lock = app.world_mut().resource_mut::<Worlds>().get_or_insert(
+        WorldName::new("minecraft:overworld"),
+        384,
+        -64,
+        &RegistryHolder::default(),
+    );
+    let mut partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: -1, z: -1 },
@@ -415,7 +401,7 @@ fn spawn_and_unload_world() {
                     z: -7.5,
                 },
                 EntityKind::Player,
-                Identifier::new("minecraft:overworld"),
+                WorldName::new("minecraft:overworld"),
             ),
             MinecraftEntityId(0),
             LocalEntity,
@@ -440,7 +426,7 @@ fn spawn_and_unload_world() {
 fn test_afk_pool() {
     let mut app = make_test_app();
     let world_lock = insert_overworld(&mut app);
-    let mut partial_world = PartialInstance::default();
+    let mut partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: 0, z: 0 },
@@ -531,7 +517,7 @@ fn test_afk_pool() {
                     z: 1.5,
                 },
                 EntityKind::Player,
-                Identifier::new("minecraft:overworld"),
+                WorldName::new("minecraft:overworld"),
             ),
             MinecraftEntityId(0),
             LocalEntity,

--- a/azalea-protocol/Cargo.toml
+++ b/azalea-protocol/Cargo.toml
@@ -23,6 +23,7 @@ azalea-entity = { workspace = true }
 azalea-inventory.workspace = true
 azalea-protocol-macros.workspace = true
 azalea-registry.workspace = true
+azalea-world = { workspace = true, optional = true }
 bevy_ecs = { workspace = true, optional = true }
 # byteorder.workspace = true
 flate2.workspace = true
@@ -46,7 +47,12 @@ reqwest = { workspace = true, optional = true, features = ["socks"] }
 default = ["online-mode", "connecting"]
 connecting = []
 online-mode = ["azalea-auth/online-mode", "dep:reqwest"]
-bevy_ecs = ["dep:bevy_ecs", "azalea-entity/bevy_ecs", "azalea-core/bevy_ecs"]
+bevy_ecs = [
+    "dep:bevy_ecs",
+    "dep:azalea-world",
+    "azalea-entity/bevy_ecs",
+    "azalea-core/bevy_ecs",
+]
 
 [lints]
 workspace = true

--- a/azalea-protocol/src/packets/game/c_add_entity.rs
+++ b/azalea-protocol/src/packets/game/c_add_entity.rs
@@ -3,7 +3,7 @@ use azalea_core::{delta::LpVec3, entity_id::MinecraftEntityId, position::Vec3};
 use azalea_protocol_macros::ClientboundGamePacket;
 use azalea_registry::builtin::EntityKind;
 #[cfg(feature = "bevy_ecs")]
-use azalea_registry::identifier::Identifier;
+use azalea_world::WorldName;
 use uuid::Uuid;
 
 #[derive(AzBuf, ClientboundGamePacket, Clone, Debug, PartialEq)]
@@ -36,7 +36,7 @@ impl ClientboundAddEntity {
     /// You must apply the metadata after inserting the bundle with
     /// [`Self::apply_metadata`].
     #[cfg(feature = "bevy_ecs")]
-    pub fn as_entity_bundle(&self, world_name: Identifier) -> azalea_entity::EntityBundle {
+    pub fn as_entity_bundle(&self, world_name: WorldName) -> azalea_entity::EntityBundle {
         azalea_entity::EntityBundle::new(self.uuid, self.position, self.entity_type, world_name)
     }
 

--- a/azalea-world/src/find_blocks.rs
+++ b/azalea-world/src/find_blocks.rs
@@ -1,9 +1,9 @@
 use azalea_block::{BlockState, BlockStates};
 use azalea_core::position::{BlockPos, ChunkPos};
 
-use crate::{Chunk, ChunkStorage, Instance, iterators::ChunkIterator, palette::Palette};
+use crate::{Chunk, ChunkStorage, World, iterators::ChunkIterator, palette::Palette};
 
-impl Instance {
+impl World {
     /// Find the coordinates of a block in the world.
     ///
     /// Note that this is sorted by `x+y+z` and not `x^2+y^2+z^2` for
@@ -206,8 +206,8 @@ impl Iterator for FindBlocks<'_> {
 /// An optimized function for finding the block positions in a chunk that match
 /// the given block states.
 ///
-/// This is used internally by [`Instance::find_block`] and
-/// [`Instance::find_blocks`].
+/// This is used internally by [`World::find_block`] and
+/// [`World::find_blocks`].
 pub fn find_blocks_in_chunk(
     block_states: &BlockStates,
     chunk_pos: ChunkPos,
@@ -257,9 +257,9 @@ mod tests {
 
     #[test]
     fn find_block() {
-        let mut instance = Instance::default();
+        let mut world = World::default();
 
-        let chunk_storage = &mut instance.chunks;
+        let chunk_storage = &mut world.chunks;
         let mut partial_chunk_storage = PartialChunkStorage::default();
 
         // block at (17, 0, 0) and (0, 18, 0)
@@ -278,15 +278,15 @@ mod tests {
         chunk_storage.set_block_state(BlockPos { x: 17, y: 0, z: 0 }, BlockKind::Stone.into());
         chunk_storage.set_block_state(BlockPos { x: 0, y: 18, z: 0 }, BlockKind::Stone.into());
 
-        let pos = instance.find_block(BlockPos { x: 0, y: 0, z: 0 }, &BlockKind::Stone.into());
+        let pos = world.find_block(BlockPos { x: 0, y: 0, z: 0 }, &BlockKind::Stone.into());
         assert_eq!(pos, Some(BlockPos { x: 17, y: 0, z: 0 }));
     }
 
     #[test]
     fn find_block_next_to_chunk_border() {
-        let mut instance = Instance::default();
+        let mut world = World::default();
 
-        let chunk_storage = &mut instance.chunks;
+        let chunk_storage = &mut world.chunks;
         let mut partial_chunk_storage = PartialChunkStorage::default();
 
         // block at (-1, 0, 0) and (15, 0, 0)
@@ -305,7 +305,7 @@ mod tests {
         chunk_storage.set_block_state(BlockPos { x: -1, y: 0, z: 0 }, BlockKind::Stone.into());
         chunk_storage.set_block_state(BlockPos { x: 15, y: 0, z: 0 }, BlockKind::Stone.into());
 
-        let pos = instance.find_block(BlockPos { x: 0, y: 0, z: 0 }, &BlockKind::Stone.into());
+        let pos = world.find_block(BlockPos { x: 0, y: 0, z: 0 }, &BlockKind::Stone.into());
         assert_eq!(pos, Some(BlockPos { x: -1, y: 0, z: 0 }));
     }
 }

--- a/azalea-world/src/lib.rs
+++ b/azalea-world/src/lib.rs
@@ -12,5 +12,12 @@ mod world;
 
 pub use bit_storage::BitStorage;
 pub use chunk_storage::{Chunk, ChunkStorage, PartialChunkStorage, Section};
-pub use container::{InstanceContainer, InstanceName};
+pub use container::{Worlds, WorldName};
 pub use world::*;
+
+#[deprecated = "renamed to `WorldName`."]
+pub type InstanceName = WorldName;
+#[deprecated = "renamed to `WorldContainer`."]
+pub type InstanceContainer = Worlds;
+#[deprecated = "renamed to `PartialWorld`."]
+pub type PartialInstance = PartialWorld;

--- a/azalea-world/src/world.rs
+++ b/azalea-world/src/world.rs
@@ -14,30 +14,30 @@ use nohash_hasher::IntMap;
 
 use crate::{ChunkStorage, PartialChunkStorage};
 
-/// PartialInstances are usually owned by clients, and hold strong references to
-/// chunks and entities in [`Instance`]s.
+/// A reference to a slice of the world, as seen by an individual client.
 ///
-/// Basically, they hold the chunks and entities that are within render
-/// distance but can still access chunks and entities owned by other
-/// `PartialInstance`s that have the same `Instance`.
+/// A `PartialWorld` will typically be owned by a client, and it holds strong
+/// references to chunks and entities in a [`World`]s.
 ///
-/// This is primarily useful for having multiple clients in the same Instance.
-pub struct PartialInstance {
+/// In other words, this type holds the chunks and entities that are within
+/// render distance for a client. The same chunk/entity may be referenced by
+/// more than one `PartialWorld`.
+pub struct PartialWorld {
     pub chunks: PartialChunkStorage,
     /// Some metadata about entities, like what entities are in certain chunks.
     /// This does not contain the entity data itself, that's in the ECS.
     pub entity_infos: PartialEntityInfos,
 }
 
-impl PartialInstance {
+impl PartialWorld {
     pub fn new(chunk_radius: u32, owner_entity: Option<Entity>) -> Self {
-        PartialInstance {
+        PartialWorld {
             chunks: PartialChunkStorage::new(chunk_radius),
             entity_infos: PartialEntityInfos::new(owner_entity),
         }
     }
 
-    /// Clears the internal references to chunks in the PartialInstance and
+    /// Clears the internal references to chunks in the [`PartialWorld`] and
     /// resets the view center.
     pub fn reset(&mut self) {
         self.chunks = PartialChunkStorage::new(self.chunks.chunk_radius);
@@ -75,16 +75,21 @@ impl PartialEntityInfos {
     }
 }
 
-/// A world where the chunks are stored as weak pointers. This is used for
-/// shared worlds.
+/// A Minecraft world, sometimes referred to as a dimension.
 ///
-/// Also see [`PartialInstance`].
+/// This is the most commonly used type to interact with the world that a client
+/// is in. In here, all chunks are stored as weak pointers, which means that
+/// clients in different areas of the same world can share the same `World`
+/// instance.
 ///
-/// This is sometimes interchangeably called a "world". However, this type is
-/// called `Instance` to avoid colliding with the `World` type from Bevy ECS.
+/// Also see [`PartialWorld`].
+///
+/// Note that this is distinct from Bevy's `World` type, which contains all of
+/// the data for every client. When referring to the Bevy `World` within Azalea,
+/// the term "ECS" is generally used instead.
 #[derive(Debug, Default)]
-#[doc(alias("world", "dimension"))]
-pub struct Instance {
+#[doc(alias("instance", "dimension", "level"))]
+pub struct World {
     pub chunks: ChunkStorage,
 
     /// An index of all the entities we know are in the chunks of the world
@@ -101,7 +106,10 @@ pub struct Instance {
     pub registries: RegistryHolder,
 }
 
-impl Instance {
+#[deprecated = "renamed to `World`."]
+pub type Instance = World;
+
+impl World {
     /// Get the block at the given position, or `None` if it's outside of the
     /// world that we have loaded.
     pub fn get_block_state(&self, pos: BlockPos) -> Option<BlockState> {
@@ -131,17 +139,17 @@ impl Instance {
     }
 }
 
-impl Debug for PartialInstance {
+impl Debug for PartialWorld {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PartialInstance")
+        f.debug_struct("PartialWorld")
             .field("chunks", &self.chunks)
             .field("entity_infos", &self.entity_infos)
             .finish()
     }
 }
 
-impl Default for PartialInstance {
-    /// Creates a completely self-contained `PartialInstance`. This is only for
+impl Default for PartialWorld {
+    /// Creates a completely self-contained [`PartialWorld`]. This is only for
     /// testing and shouldn't be used in actual code!
     fn default() -> Self {
         let chunk_storage = PartialChunkStorage::default();
@@ -153,7 +161,7 @@ impl Default for PartialInstance {
     }
 }
 
-impl From<ChunkStorage> for Instance {
+impl From<ChunkStorage> for World {
     /// Make an empty world from this `ChunkStorage`. This is meant to be a
     /// convenience function for tests.
     fn from(chunks: ChunkStorage) -> Self {

--- a/azalea/examples/testbot/commands/debug.rs
+++ b/azalea/examples/testbot/commands/debug.rs
@@ -15,7 +15,7 @@ use azalea::{
 use azalea_core::hit_result::HitResult;
 use azalea_entity::{EntityKindComponent, metadata};
 use azalea_inventory::components::MaxStackSize;
-use azalea_world::InstanceContainer;
+use azalea_world::Worlds;
 use bevy_app::AppExit;
 use bevy_ecs::{message::Messages, query::With, world::EntityRef};
 use parking_lot::Mutex;
@@ -331,16 +331,16 @@ pub fn register(commands: &mut CommandDispatcher<Mutex<CommandSource>>) {
                 // info.layout().size()).unwrap();
 
                 match name.as_ref() {
-                    "azalea_world::container::InstanceContainer" => {
-                        let instance_container = ecs.resource::<InstanceContainer>();
+                    "azalea_world::container::Worlds" => {
+                        let worlds = ecs.resource::<Worlds>();
 
-                        for (instance_name, instance) in &instance_container.instances {
-                            writeln!(report, "- Name: {instance_name}").unwrap();
-                            writeln!(report, "- Reference count: {}", instance.strong_count())
+                        for (world_name, world) in &worlds.map {
+                            writeln!(report, "- Name: {world_name}").unwrap();
+                            writeln!(report, "- Reference count: {}", world.strong_count())
                                 .unwrap();
-                            if let Some(instance) = instance.upgrade() {
-                                let instance = instance.read();
-                                let strong_chunks = instance
+                            if let Some(world) = world.upgrade() {
+                                let world = world.read();
+                                let strong_chunks = world
                                     .chunks
                                     .map
                                     .iter()
@@ -350,13 +350,13 @@ pub fn register(commands: &mut CommandDispatcher<Mutex<CommandSource>>) {
                                     report,
                                     "- Chunks: {} strongly referenced, {} in map",
                                     strong_chunks,
-                                    instance.chunks.map.len()
+                                    world.chunks.map.len()
                                 )
                                 .unwrap();
                                 writeln!(
                                     report,
                                     "- Entities: {}",
-                                    instance.entities_by_chunk.len()
+                                    world.entities_by_chunk.len()
                                 )
                                 .unwrap();
                             }

--- a/azalea/src/entity_ref/mod.rs
+++ b/azalea/src/entity_ref/mod.rs
@@ -57,9 +57,9 @@ impl EntityRef {
     /// # Examples
     ///
     /// ```
-    /// # use azalea_world::InstanceName;
+    /// # use azalea_world::WorldName;
     /// # fn example(client: &azalea::Client) {
-    /// let world_name = client.component::<InstanceName>();
+    /// let world_name = client.component::<WorldName>();
     /// # }
     pub fn component<T: Component>(&self) -> MappedRwLockReadGuard<'_, T> {
         self.client.entity_component(self.entity)

--- a/azalea/src/entity_ref/shared_impls.rs
+++ b/azalea/src/entity_ref/shared_impls.rs
@@ -2,7 +2,7 @@ use azalea_core::{entity_id::MinecraftEntityId, position::Vec3};
 use azalea_entity::{
     Attributes, Dead, EntityUuid, Physics, Position, dimensions::EntityDimensions, metadata::Health,
 };
-use azalea_world::InstanceName;
+use azalea_world::WorldName;
 use uuid::Uuid;
 
 use super::EntityRef;
@@ -141,21 +141,29 @@ impl_entity_functions! {
     }
 
     Client:
-    /// Get the name of the instance (world) that the bot is in.
+    #[deprecated = "renamed to `world_name`."]
+    EntityRef:
+    #[deprecated = "renamed to `world_name`."]
+    pub fn instance_name(&self) -> WorldName {
+        self.world_name()
+    }
+
+    Client:
+    /// Get the name of the world that the bot is in.
     ///
     /// This can be used to check if the client is in the same world as another
     /// entity.
-    #[doc(alias("world_name", "dimension_name"))]
+    #[doc(alias("dimension_name"))]
     EntityRef:
-    /// Get the name of the instance (world) that the entity is in.
+    /// Get the name of the world that the entity is in.
     ///
     /// This can be used to check if the entity is in the same world as another
     /// entity.
     ///
-    /// Also see [`Client::instance_name`],
-    #[doc(alias("world_name", "dimension_name"))]
-    pub fn instance_name(&self) -> InstanceName {
-        (*self.component::<InstanceName>()).clone()
+    /// Also see [`Client::world_name`],
+    #[doc(alias("dimension_name"))]
+    pub fn world_name(&self) -> WorldName {
+        (*self.component::<WorldName>()).clone()
     }
 
     Client:

--- a/azalea/src/events.rs
+++ b/azalea/src/events.rs
@@ -7,7 +7,7 @@ use azalea_chat::FormattedText;
 use azalea_core::{entity_id::MinecraftEntityId, position::ChunkPos, tick::GameTick};
 use azalea_entity::{Dead, InLoadedChunk};
 use azalea_protocol::packets::game::c_player_combat_kill::ClientboundPlayerCombatKill;
-use azalea_world::InstanceName;
+use azalea_world::WorldName;
 use bevy_app::{App, Plugin, PreUpdate, Update};
 use bevy_ecs::prelude::*;
 use derive_more::{Deref, DerefMut};
@@ -211,7 +211,7 @@ pub fn chat_listener(
 }
 
 // only tick if we're in a world
-pub fn tick_listener(query: Query<&LocalPlayerEvents, With<InstanceName>>) {
+pub fn tick_listener(query: Query<&LocalPlayerEvents, With<WorldName>>) {
     for local_player_events in &query {
         let _ = local_player_events.send(Event::Tick);
     }

--- a/azalea/src/nearest_entity.rs
+++ b/azalea/src/nearest_entity.rs
@@ -1,6 +1,6 @@
 use azalea_core::entity_id::MinecraftEntityId;
 use azalea_entity::Position;
-use azalea_world::InstanceName;
+use azalea_world::WorldName;
 use bevy_ecs::{
     prelude::Entity,
     query::{QueryFilter, With},
@@ -11,8 +11,8 @@ use bevy_ecs::{
 /// entity, (or several) close to a given position.
 ///
 /// This system parameter allows for additional filtering of entities based off
-/// of ECS marker components, such as `With<>`, `Without<>`, or `Added<>`, etc.
-/// All functions used by this system parameter instance will respect the
+/// of ECS marker components, such as `With<T>`, `Without<T>`, or `Added<T>`,
+/// etc. All functions used by this system parameter instance will respect the
 /// applied filter.
 ///
 /// ```
@@ -50,13 +50,12 @@ pub struct EntityFinder<'w, 's, F = ()>
 where
     F: QueryFilter + 'static,
 {
-    all_entities:
-        Query<'w, 's, (&'static Position, &'static InstanceName), With<MinecraftEntityId>>,
+    all_entities: Query<'w, 's, (&'static Position, &'static WorldName), With<MinecraftEntityId>>,
 
     filtered_entities: Query<
         'w,
         's,
-        (Entity, &'static InstanceName, &'static Position),
+        (Entity, &'static WorldName, &'static Position),
         (With<MinecraftEntityId>, F),
     >,
 }
@@ -65,21 +64,22 @@ impl<'a, F> EntityFinder<'_, '_, F>
 where
     F: QueryFilter + 'static,
 {
-    /// Gets the nearest entity to the given position and world instance name.
+    /// Gets the nearest entity to the given position and with the given world
+    /// name.
     ///
     /// This method will return `None` if there are no entities within range. If
     /// multiple entities are within range, only the closest one is returned.
     pub fn nearest_to_position(
         &'a self,
         position: Position,
-        instance_name: &InstanceName,
+        world_name: &WorldName,
         max_distance: f64,
     ) -> Option<Entity> {
         let mut nearest_entity = None;
         let mut min_distance = max_distance;
 
-        for (target_entity, e_instance, e_pos) in self.filtered_entities.iter() {
-            if e_instance != instance_name {
+        for (target_entity, e_world, e_pos) in self.filtered_entities.iter() {
+            if e_world != world_name {
                 continue;
             }
 
@@ -99,19 +99,19 @@ where
     /// multiple entities are within range, only the closest one is
     /// returned.
     pub fn nearest_to_entity(&'a self, entity: Entity, max_distance: f64) -> Option<Entity> {
-        let Ok((position, instance_name)) = self.all_entities.get(entity) else {
+        let Ok((position, world_name)) = self.all_entities.get(entity) else {
             return None;
         };
 
         let mut nearest_entity = None;
         let mut min_distance = max_distance;
 
-        for (target_entity, e_instance, e_pos) in self.filtered_entities.iter() {
+        for (target_entity, e_world, e_pos) in self.filtered_entities.iter() {
             if entity == target_entity {
                 continue;
             };
 
-            if e_instance != instance_name {
+            if e_world != world_name {
                 continue;
             }
 
@@ -135,13 +135,13 @@ where
     pub fn nearby_entities_to_position(
         &'a self,
         position: &'a Position,
-        instance_name: &'a InstanceName,
+        world_name: &'a WorldName,
         max_distance: f64,
     ) -> impl Iterator<Item = (Entity, f64)> + 'a {
         self.filtered_entities
             .iter()
-            .filter_map(move |(target_entity, e_instance, e_pos)| {
-                if e_instance != instance_name {
+            .filter_map(move |(target_entity, e_world, e_pos)| {
+                if e_world != world_name {
                     return None;
                 }
 
@@ -167,23 +167,23 @@ where
         max_distance: f64,
     ) -> impl Iterator<Item = (Entity, f64)> + 'a {
         let position;
-        let instance_name;
-        if let Ok((pos, instance)) = self.all_entities.get(entity) {
-            position = *pos;
-            instance_name = Some(instance);
+        let world_name;
+        if let Ok((p, w)) = self.all_entities.get(entity) {
+            position = *p;
+            world_name = Some(w);
         } else {
             position = Position::default();
-            instance_name = None;
+            world_name = None;
         };
 
         self.filtered_entities
             .iter()
-            .filter_map(move |(target_entity, e_instance, e_pos)| {
+            .filter_map(move |(target_entity, e_world, e_pos)| {
                 if entity == target_entity {
                     return None;
                 }
 
-                if Some(e_instance) != instance_name {
+                if Some(e_world) != world_name {
                     return None;
                 }
 

--- a/azalea/src/pathfinder/debug.rs
+++ b/azalea/src/pathfinder/debug.rs
@@ -1,4 +1,4 @@
-use azalea_client::{chat::SendChatEvent, local_player::InstanceHolder};
+use azalea_client::{chat::SendChatEvent, local_player::WorldHolder};
 use azalea_core::position::Vec3;
 use bevy_ecs::prelude::*;
 
@@ -35,7 +35,7 @@ use super::ExecutingPath;
 pub struct PathfinderDebugParticles;
 
 pub fn debug_render_path_with_particles(
-    mut query: Query<(Entity, &ExecutingPath, &InstanceHolder), With<PathfinderDebugParticles>>,
+    mut query: Query<(Entity, &ExecutingPath, &WorldHolder), With<PathfinderDebugParticles>>,
     // chat_events is Option because the tests don't have SendChatEvent
     // and we have to use ResMut<Messages> because bevy doesn't support Option<MessageWriter>
     chat_events: Option<ResMut<Messages<SendChatEvent>>>,
@@ -50,12 +50,12 @@ pub fn debug_render_path_with_particles(
         *tick_count += 1;
         return;
     }
-    for (entity, executing_path, instance_holder) in &mut query {
+    for (entity, executing_path, world_holder) in &mut query {
         if executing_path.path.is_empty() {
             continue;
         }
 
-        let chunks = &instance_holder.instance.read().chunks;
+        let chunks = &world_holder.shared.read().chunks;
 
         let mut start = executing_path.last_reached_node;
         for (i, edge) in executing_path.path.iter().enumerate() {

--- a/azalea/src/pathfinder/extras/utils.rs
+++ b/azalea/src/pathfinder/extras/utils.rs
@@ -115,13 +115,13 @@ pub fn get_hit_result_while_looking_at_with_eye_position(
 #[cfg(test)]
 mod tests {
     use azalea_core::position::ChunkPos;
-    use azalea_world::{Chunk, PartialInstance};
+    use azalea_world::{Chunk, PartialWorld};
 
     use super::*;
 
     #[test]
     fn test_cannot_reach_block_through_wall_when_y_is_negative() {
-        let mut partial_world = PartialInstance::default();
+        let mut partial_world = PartialWorld::default();
         let mut world = ChunkStorage::default();
         partial_world
             .chunks

--- a/azalea/src/pathfinder/moves/mod.rs
+++ b/azalea/src/pathfinder/moves/mod.rs
@@ -13,7 +13,7 @@ use azalea_client::{
 };
 use azalea_core::position::{BlockPos, Vec3};
 use azalea_inventory::Menu;
-use azalea_world::Instance;
+use azalea_world::World;
 use bevy_ecs::{entity::Entity, message::MessageWriter, system::Commands};
 use parking_lot::RwLock;
 use tracing::debug;
@@ -65,7 +65,7 @@ pub struct ExecuteCtx<'s, 'w1, 'w2, 'w3, 'w4, 'w5, 'w6, 'a> {
     pub position: Vec3,
     pub physics: &'a azalea_entity::Physics,
     pub is_currently_mining: bool,
-    pub instance: Arc<RwLock<Instance>>,
+    pub world: Arc<RwLock<World>>,
     pub menu: Menu,
 
     pub commands: &'a mut Commands<'w1, 's>,
@@ -124,11 +124,7 @@ impl ExecuteCtx<'_, '_, '_, '_, '_, '_, '_, '_> {
 
     /// Returns whether this block could be mined.
     pub fn should_mine(&mut self, block: BlockPos) -> bool {
-        let block_state = self
-            .instance
-            .read()
-            .get_block_state(block)
-            .unwrap_or_default();
+        let block_state = self.world.read().get_block_state(block).unwrap_or_default();
         if is_block_state_passable(block_state) {
             // block is already passable, no need to mine it
             return false;
@@ -141,11 +137,7 @@ impl ExecuteCtx<'_, '_, '_, '_, '_, '_, '_, '_> {
     ///
     /// Returns whether the block is being mined.
     pub fn mine(&mut self, block: BlockPos) -> bool {
-        let block_state = self
-            .instance
-            .read()
-            .get_block_state(block)
-            .unwrap_or_default();
+        let block_state = self.world.read().get_block_state(block).unwrap_or_default();
         if is_block_state_passable(block_state) {
             // block is already passable, no need to mine it
             return false;
@@ -196,10 +188,7 @@ impl ExecuteCtx<'_, '_, '_, '_, '_, '_, '_, '_> {
     }
 
     pub fn get_block_state(&self, block: BlockPos) -> BlockState {
-        self.instance
-            .read()
-            .get_block_state(block)
-            .unwrap_or_default()
+        self.world.read().get_block_state(block).unwrap_or_default()
     }
 }
 

--- a/azalea/src/pathfinder/world.rs
+++ b/azalea/src/pathfinder/world.rs
@@ -11,7 +11,7 @@ use azalea_core::{
 };
 use azalea_physics::collision::BlockWithShape;
 use azalea_registry::{builtin::BlockKind, tags};
-use azalea_world::{Instance, palette::PalettedContainer};
+use azalea_world::{World, palette::PalettedContainer};
 use parking_lot::RwLock;
 
 use super::{mining::MiningCache, rel_block_pos::RelBlockPos};
@@ -25,7 +25,7 @@ pub struct CachedWorld {
     origin: BlockPos,
 
     min_y: i32,
-    world_lock: Arc<RwLock<Instance>>,
+    world_lock: Arc<RwLock<World>>,
 
     // we store `PalettedContainer`s instead of `Chunk`s or `Section`s because it doesn't contain
     // any unnecessary data like heightmaps or biomes.
@@ -99,7 +99,7 @@ pub struct CachedSection {
 }
 
 impl CachedWorld {
-    pub fn new(world_lock: Arc<RwLock<Instance>>, origin: BlockPos) -> Self {
+    pub fn new(world_lock: Arc<RwLock<World>>, origin: BlockPos) -> Self {
         let min_y = world_lock.read().chunks.min_y;
         Self {
             origin,
@@ -675,13 +675,13 @@ pub fn is_block_state_water(block_state: BlockState) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use azalea_world::{Chunk, ChunkStorage, PartialInstance};
+    use azalea_world::{Chunk, ChunkStorage, PartialWorld};
 
     use super::*;
 
     #[test]
     fn test_is_passable() {
-        let mut partial_world = PartialInstance::default();
+        let mut partial_world = PartialWorld::default();
         let mut world = ChunkStorage::default();
 
         partial_world
@@ -703,7 +703,7 @@ mod tests {
 
     #[test]
     fn test_is_solid() {
-        let mut partial_world = PartialInstance::default();
+        let mut partial_world = PartialWorld::default();
         let mut world = ChunkStorage::default();
         partial_world
             .chunks
@@ -724,7 +724,7 @@ mod tests {
 
     #[test]
     fn test_is_standable() {
-        let mut partial_world = PartialInstance::default();
+        let mut partial_world = PartialWorld::default();
         let mut world = ChunkStorage::default();
         partial_world
             .chunks

--- a/azalea/src/swarm/builder.rs
+++ b/azalea/src/swarm/builder.rs
@@ -10,7 +10,7 @@ use std::{
 
 use azalea_client::{DefaultPlugins, account::Account, start_ecs_runner};
 use azalea_protocol::address::{ResolvableAddr, ResolvedAddr};
-use azalea_world::InstanceContainer;
+use azalea_world::Worlds;
 use bevy_app::{App, AppExit, Plugins, SubApp};
 use bevy_ecs::{component::Component, resource::Resource};
 use futures::future::join_all;
@@ -431,7 +431,7 @@ where
             addr
         };
 
-        let instance_container = Arc::new(RwLock::new(InstanceContainer::default()));
+        let worlds = Arc::new(RwLock::new(Worlds::default()));
 
         // we can't modify the swarm plugins after this
         let (bots_tx, mut bots_rx) = mpsc::unbounded_channel();
@@ -451,7 +451,7 @@ where
                 ecs: ecs_lock.clone(),
 
                 address: Arc::new(RwLock::new(address)),
-                instance_container,
+                worlds,
 
                 bots_tx,
 

--- a/azalea/src/swarm/chat.rs
+++ b/azalea/src/swarm/chat.rs
@@ -2,12 +2,12 @@
 
 // How the chat event works (to avoid firing the event multiple times):
 // ---
-// There's a shared queue of all the chat messages
-// Each bot contains an index of the farthest message we've seen
-// When a bot receives a chat messages, it looks into the queue to find the
-// earliest instance of the message content that's after the bot's chat index.
-// If it finds it, then its personal index is simply updated. Otherwise, fire
-// the event and add to the queue.
+// There's a shared queue of all the chat messages. Each bot contains an index
+// of the farthest message that it has seen. When a bot receives a chat
+// message, it looks into the shared queue to find the earliest instance of the
+// message content, that's after the bot's current chat index. If it finds it,
+// then its personal index is simply updated. Otherwise, it fires the event and
+// adds to the shared queue.
 //
 // To make sure the queue doesn't grow too large, we keep a `chat_min_index`
 // in Swarm that's set to the smallest index of all the bots, and we remove all

--- a/azalea/src/swarm/events.rs
+++ b/azalea/src/swarm/events.rs
@@ -1,4 +1,4 @@
-use azalea_client::local_player::InstanceHolder;
+use azalea_client::local_player::WorldHolder;
 use azalea_core::entity_id::MinecraftEntityId;
 use bevy_app::{App, Plugin, Update};
 use bevy_ecs::prelude::*;
@@ -21,7 +21,7 @@ pub struct SwarmReadyEvent;
 struct IsSwarmReady(bool);
 
 fn check_ready(
-    query: Query<Option<&MinecraftEntityId>, With<InstanceHolder>>,
+    query: Query<Option<&MinecraftEntityId>, With<WorldHolder>>,
     mut is_swarm_ready: ResMut<IsSwarmReady>,
     mut ready_events: MessageWriter<SwarmReadyEvent>,
 ) {

--- a/azalea/src/swarm/mod.rs
+++ b/azalea/src/swarm/mod.rs
@@ -15,7 +15,7 @@ use std::sync::{
 use azalea_client::{account::Account, chat::ChatPacket, join::ConnectOpts};
 use azalea_entity::LocalEntity;
 use azalea_protocol::address::ResolvedAddr;
-use azalea_world::InstanceContainer;
+use azalea_world::Worlds;
 use bevy_app::{PluginGroup, PluginGroupBuilder};
 use bevy_ecs::prelude::*;
 pub use builder::SwarmBuilder;
@@ -47,7 +47,7 @@ pub struct Swarm {
     // the address is public and mutable so plugins can change it
     pub address: Arc<RwLock<ResolvedAddr>>,
 
-    pub instance_container: Arc<RwLock<InstanceContainer>>,
+    pub worlds: Arc<RwLock<Worlds>>,
 
     /// This is used internally to make the client handler function work.
     pub(crate) bots_tx: mpsc::UnboundedSender<(Option<crate::Event>, Client)>,


### PR DESCRIPTION
In the past, Azalea referred to worlds as a `World`. When Azalea switched to Bevy ECS, this introduced a collision, as Bevy also refers to the ECS as the `World`.

To work around this problem, I created an `azalea-ecs` crate that simply re-exported the `bevy_ecs` types, but with a couple renamed ones (including `World` -> `Ecs`). This sort of worked, but it meant that all of Bevy's macros had to be copy-pasted and updated to use the different names. It also meant that Azalea would be slightly less friendly to new users coming from Bevy.

Due to these reasons, eventually I got rid of `azalea-ecs` and just renamed `World` to `Instance`, taking inspiration from Minestom. This is how it has stayed for the last few years, but I was never particularly fond of the name `Instance`. I was kind of hoping that Bevy would eventually rename their `World` to something more appropriate -- and they've discussed this a few times before -- but sadly it hasn't come to fruition yet. However, I've increasingly seen users get confused by Azalea's terminology, since `Instance` isn't particularly intuitive.

After much deliberation (considering names like `WorldInstance`, `Dimension`, `Level`, `Realm`, etc), I have decided that it would make the most sense to name `Instance` back to just plain `World`, despite the name collision. There simply is not a good alternative to the name `World`, and I do not think the collision is as relevant as it was in the past, because Azalea has been updated in ways that don't require the user to have to directly interact with the ECS as much anymore.

This PR updates all of the code and documentation that refers to "instance" to use "world" instead (manually updated of course, not blindly replacing). A few other names were changed to make them more appropriate as well (including `InstanceContainer` -> `Worlds` and `InstanceHolder::partial_instance` -> `partial`).

As usual, type aliases and `#[deprecated]` markers were added for renamed types to make it easier for users to update their existing code.

