### PR TITLE
fix AirSupply metadata defaulting to 0 instead of 300

### DIFF
--- a/azalea-entity/src/metadata.rs
+++ b/azalea-entity/src/metadata.rs
@@ -547,7 +547,7 @@ impl Default for AbstractEntityMetadataBundle {
             currently_glowing: CurrentlyGlowing(false),
             invisible: Invisible(false),
             fall_flying: FallFlying(false),
-            air_supply: AirSupply(Default::default()),
+            air_supply: AirSupply(300),
             custom_name: CustomName(Default::default()),
             custom_name_visible: CustomNameVisible(Default::default()),
             silent: Silent(Default::default()),

--- a/codegen/lib/code/entity.py
+++ b/codegen/lib/code/entity.py
@@ -546,6 +546,12 @@ impl From<EntityDataValue> for UpdateMetadataError {
                             default = f"azalea_registry::data::{type_name}::new_raw(0)"
                         elif type_name == "VillagerData":
                             default = "VillagerData { kind: azalea_registry::builtin::VillagerKind::Plains, profession: azalea_registry::builtin::VillagerProfession::None, level: 0 }"
+                        elif name == "air_supply":
+                            # Burger doesn't extract defaults for `Int` metadata fields, but Mojang
+                            # defaults AirSupply to 300 (Entity.java: defineId(..., 300)). Without
+                            # this override, a non-drowning entity reports air=0 because
+                            # SynchedEntityData only syncs non-default values.
+                            default = "300"
                         else:
                             default = (
                                 f"{type_name}::default()"


### PR DESCRIPTION
## Summary
`AirSupply` defaults to 0 instead of Mojang's 300. Because `ClientboundSetEntityDataPacket` only syncs non-default fields, a freshly spawned non-drowning entity reports `air_supply=0` indefinitely.

## Root cause
`codegen/lib/code/entity.py` reads defaults from burger, which returns `None` for `Int` metadata. The `default is None` branch special-cases `CompoundTag`, `*Variant`, and `VillagerData` only; `Int` falls through to `Default::default()`.

## Fix
Add `elif name == "air_supply"` in `entity.py` setting `default = "300"`.

## Test plan
- `cargo check -p azalea-entity` passes.
