### PR TITLE
Add batch packet writing

### DIFF
--- a/azalea-protocol/src/connect.rs
+++ b/azalea-protocol/src/connect.rs
@@ -223,6 +223,15 @@ where
         self.raw.write(&serialize_packet(&packet).unwrap()).await
     }
 
+    /// Write a batch of packets to the server
+    pub async fn write_batch(&mut self, packets: impl IntoIterator<Item = W>) -> io::Result<()> {
+        let serialized_packets: Vec<u8> = packets
+            .into_iter()
+            .flat_map(|packet| serialize_packet(&packet).unwrap())
+            .collect();
+        self.raw.write(&serialized_packets).await
+    }
+
     /// End the connection.
     pub async fn shutdown(&mut self) -> io::Result<()> {
         self.raw.shutdown().await
@@ -249,6 +258,16 @@ where
     pub async fn write(&mut self, packet: impl crate::packets::Packet<W>) -> io::Result<()> {
         let packet = packet.into_variant();
         self.writer.write(packet).await
+    }
+
+    /// Write a batch of packets to the other side of the connection.
+    pub async fn write_batch(
+        &mut self,
+        packets: impl IntoIterator<Item = impl crate::packets::Packet<W>>,
+    ) -> io::Result<()> {
+        self.writer
+            .write_batch(packets.into_iter().map(|packet| packet.into_variant()))
+            .await
     }
 
     /// Split the reader and writer into two objects.

--- a/azalea-protocol/src/connect.rs
+++ b/azalea-protocol/src/connect.rs
@@ -224,10 +224,10 @@ where
     }
 
     /// Write a batch of packets to the server
-    pub async fn write_batch(&mut self, packets: impl IntoIterator<Item = W>) -> io::Result<()> {
+    pub async fn write_batch(&mut self, packets: &[W]) -> io::Result<()> {
         let serialized_packets: Vec<u8> = packets
             .into_iter()
-            .flat_map(|packet| serialize_packet(&packet).unwrap())
+            .flat_map(|packet| serialize_packet(packet).unwrap())
             .collect();
         self.raw.write(&serialized_packets).await
     }
@@ -261,13 +261,8 @@ where
     }
 
     /// Write a batch of packets to the other side of the connection.
-    pub async fn write_batch(
-        &mut self,
-        packets: impl IntoIterator<Item = impl crate::packets::Packet<W>>,
-    ) -> io::Result<()> {
-        self.writer
-            .write_batch(packets.into_iter().map(|packet| packet.into_variant()))
-            .await
+    pub async fn write_batch(&mut self, packets: &[W]) -> io::Result<()> {
+        self.writer.write_batch(packets).await
     }
 
     /// Split the reader and writer into two objects.


### PR DESCRIPTION
Closes #284 by adding a `write_batch` function to `Connection`.

Note: the function requires owned packets, so you would do
```rs
conn.write_batch(vec![packet1, packet2]).await
```
instead of
```rs
conn.write_batch(&[packet1, packet2]).await
```
I tried making it accept references, but struggled to do so. If anyone could give a pointer on how to achieve this, I would be very grateful.