### PR TITLE
fix: Frame packets correctly when writing batches

### DIFF
--- a/azalea-protocol/src/connect.rs
+++ b/azalea-protocol/src/connect.rs
@@ -37,7 +37,7 @@ use crate::{
         status::{ClientboundStatusPacket, ServerboundStatusPacket},
     },
     read::{ReadPacketError, deserialize_packet, read_raw_packet, try_read_raw_packet},
-    write::{serialize_packet, write_raw_packet},
+    write::{serialize_packet, write_raw_packet, write_raw_packets},
 };
 
 pub struct RawReadConnection {
@@ -189,6 +189,27 @@ impl RawWriteConnection {
         Ok(())
     }
 
+    pub async fn write_batch(&mut self, packets: impl Iterator<Item = &[u8]>) -> io::Result<()> {
+        if let Err(e) = write_raw_packets(
+            packets,
+            &mut self.write_stream,
+            self.compression_threshold,
+            &mut self.enc_cipher,
+        )
+        .await
+        {
+            // detect broken pipe
+            if e.kind() == io::ErrorKind::BrokenPipe {
+                info!("Broken pipe, shutting down connection.");
+                if let Err(e) = self.shutdown().await {
+                    error!("Couldn't shut down: {}", e);
+                }
+            }
+            return Err(e);
+        }
+        Ok(())
+    }
+
     /// End the connection.
     pub async fn shutdown(&mut self) -> io::Result<()> {
         self.write_stream.shutdown().await
@@ -225,11 +246,13 @@ where
 
     /// Write a batch of packets to the server
     pub async fn write_batch(&mut self, packets: &[W]) -> io::Result<()> {
-        let serialized_packets: Vec<u8> = packets
+        let serialized_packets: Vec<Box<[u8]>> = packets
             .into_iter()
-            .flat_map(|packet| serialize_packet(packet).unwrap())
+            .map(|packet| serialize_packet(packet).unwrap())
             .collect();
-        self.raw.write(&serialized_packets).await
+        self.raw
+            .write_batch(serialized_packets.iter().map(|data| data.as_ref()))
+            .await
     }
 
     /// End the connection.

--- a/azalea-protocol/src/write.rs
+++ b/azalea-protocol/src/write.rs
@@ -58,6 +58,26 @@ where
     stream.write_all(&network_packet).await
 }
 
+pub async fn write_raw_packets<W>(
+    raw_packets: impl Iterator<Item = &[u8]>,
+    stream: &mut W,
+    compression_threshold: Option<u32>,
+    cipher: &mut Option<Aes128CfbEnc>,
+) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin + Send,
+{
+    let mut buffer = Vec::new();
+    for raw_packet in raw_packets {
+        buffer.extend(encode_to_network_packet(
+            raw_packet,
+            compression_threshold,
+            cipher,
+        ));
+    }
+    stream.write_all(&buffer).await
+}
+
 pub fn encode_to_network_packet(
     raw_packet: &[u8],
     compression_threshold: Option<u32>,


### PR DESCRIPTION
Runs compression, length prepending, and encryption per packet when writing batches of packets instead of running it on the combined bytes of the serialized packets like before.

Sorry for introducing this issue in #330 :sweat_smile: 