### PR TITLE
Fix OptionalNbt framing: VarInt byte length, not bool presence

### DIFF
--- a/azalea-brigadier/src/context/context_chain.rs
+++ b/azalea-brigadier/src/context/context_chain.rs
@@ -119,15 +119,13 @@ impl<S, R: CommandResultTrait> ContextChain<S, R> {
 
             let mut next_sources = Vec::new();
             for source_to_run in current_sources {
-                match Self::run_modifier(
+                let res = Self::run_modifier(
                     modifier.clone(),
                     source_to_run.clone(),
                     result_consumer,
                     forked_mode,
-                ) {
-                    Ok(res) => next_sources.extend(res),
-                    Err(err) => return Err(err),
-                }
+                )?;
+                next_sources.extend(res);
             }
             if next_sources.is_empty() {
                 return Ok(R::new(0));

--- a/azalea-entity/src/effects.rs
+++ b/azalea-entity/src/effects.rs
@@ -4,12 +4,14 @@ use std::{
 };
 
 use azalea_buf::{AzBuf, BufReadError};
-use azalea_core::{attribute_modifier_operation::AttributeModifierOperation, bitset::FixedBitSet};
+#[cfg(feature = "bevy_ecs")]
+use azalea_core::attribute_modifier_operation::AttributeModifierOperation;
+use azalea_core::bitset::FixedBitSet;
+#[cfg(feature = "bevy_ecs")]
 use azalea_inventory::components::AttributeModifier;
-use azalea_registry::{
-    builtin::{Attribute, MobEffect},
-    identifier::Identifier,
-};
+use azalea_registry::builtin::MobEffect;
+#[cfg(feature = "bevy_ecs")]
+use azalea_registry::{builtin::Attribute, identifier::Identifier};
 
 /// Data about an active mob effect.
 #[derive(AzBuf, Clone, Debug, Default, PartialEq)]
@@ -106,6 +108,7 @@ impl ActiveEffects {
     }
 }
 
+#[cfg(feature = "bevy_ecs")]
 pub fn attribute_modifier_for_effect(id: MobEffect) -> Option<(Attribute, AttributeTemplate)> {
     Some(match id {
         MobEffect::Speed => (
@@ -196,7 +199,9 @@ pub fn attribute_modifier_for_effect(id: MobEffect) -> Option<(Attribute, Attrib
     })
 }
 
+#[cfg(feature = "bevy_ecs")]
 pub struct AttributeTemplate(AttributeModifier);
+#[cfg(feature = "bevy_ecs")]
 impl AttributeTemplate {
     pub fn new(id: &str, amount: f64, operation: AttributeModifierOperation) -> Self {
         Self(AttributeModifier {

--- a/azalea-protocol/examples/handshake_proxy.rs
+++ b/azalea-protocol/examples/handshake_proxy.rs
@@ -36,7 +36,7 @@ const PROXY_DESC: &str = "An Azalea Minecraft Proxy";
 static PROXY_FAVICON: LazyLock<Option<String>> = LazyLock::new(|| None);
 
 static PROXY_VERSION: LazyLock<Version> = LazyLock::new(|| Version {
-    name: VERSION_NAME.to_string(),
+    name: VERSION_NAME.to_owned(),
     protocol: PROTOCOL_VERSION,
 });
 

--- a/azalea-protocol/examples/packet_logger.rs
+++ b/azalea-protocol/examples/packet_logger.rs
@@ -66,7 +66,7 @@ const PROXY_DESC: &str = "An Azalea Minecraft Proxy";
 // String must be formatted like "data:image/png;base64,<data>"
 static PROXY_FAVICON: LazyLock<Option<String>> = LazyLock::new(|| None);
 static PROXY_VERSION: LazyLock<Version> = LazyLock::new(|| Version {
-    name: VERSION_NAME.to_string(),
+    name: VERSION_NAME.to_owned(),
     protocol: PROTOCOL_VERSION,
 });
 const PROXY_PLAYERS: Players = Players {

--- a/azalea-protocol/src/packets/config/s_custom_click_action.rs
+++ b/azalea-protocol/src/packets/config/s_custom_click_action.rs
@@ -1,10 +1,11 @@
 use azalea_buf::AzBuf;
 use azalea_registry::identifier::Identifier;
 use azalea_protocol_macros::ServerboundConfigPacket;
-use simdnbt::owned::Nbt;
+
+use crate::packets::OptionalNbt;
 
 #[derive(AzBuf, Clone, Debug, PartialEq, ServerboundConfigPacket)]
 pub struct ServerboundCustomClickAction {
     pub id: Identifier,
-    pub payload: Nbt,
+    pub payload: OptionalNbt,
 }

--- a/azalea-protocol/src/packets/game/s_custom_click_action.rs
+++ b/azalea-protocol/src/packets/game/s_custom_click_action.rs
@@ -1,10 +1,11 @@
 use azalea_buf::AzBuf;
 use azalea_registry::identifier::Identifier;
 use azalea_protocol_macros::ServerboundGamePacket;
-use simdnbt::owned::Nbt;
+
+use crate::packets::OptionalNbt;
 
 #[derive(AzBuf, Clone, Debug, PartialEq, ServerboundGamePacket)]
 pub struct ServerboundCustomClickAction {
     pub id: Identifier,
-    pub payload: Nbt,
+    pub payload: OptionalNbt,
 }

--- a/azalea-protocol/src/packets/mod.rs
+++ b/azalea-protocol/src/packets/mod.rs
@@ -5,11 +5,68 @@ pub mod handshake;
 pub mod login;
 pub mod status;
 
-use std::io::{self, Cursor, Write};
+use std::io::{self, Cursor, Read, Write};
 
 use azalea_buf::{AzBuf, AzBufVar, BufReadError};
 
 use crate::read::ReadPacketError;
+
+/// Network NBT framed as a VarInt byte length followed by an unnamed NBT
+/// compound. A length of `0` means no NBT payload is present.
+///
+/// This is the 26.1.2 / Minecraft 1.21.5+ `Custom Click Action` payload
+/// framing used by vanilla's `FriendlyByteBuf::writeNbt` / `readNbt`
+/// contract. Historically this was represented as a bare `Nbt`, which wrote
+/// the compound directly and corrupted framing for non-empty payloads.
+#[derive(Clone, Debug, PartialEq)]
+pub struct OptionalNbt(pub simdnbt::owned::Nbt);
+
+impl OptionalNbt {
+    pub fn empty() -> Self {
+        Self(simdnbt::owned::Nbt::None)
+    }
+}
+
+impl From<simdnbt::owned::Nbt> for OptionalNbt {
+    fn from(value: simdnbt::owned::Nbt) -> Self {
+        Self(value)
+    }
+}
+
+impl AzBuf for OptionalNbt {
+    fn azalea_read(buf: &mut Cursor<&[u8]>) -> Result<Self, BufReadError> {
+        let length = i32::azalea_read_var(buf)?;
+        if length == 0 {
+            Ok(OptionalNbt(simdnbt::owned::Nbt::None))
+        } else if length < 0 {
+            Err(BufReadError::Custom(format!(
+                "OptionalNbt length was negative: {length}"
+            )))
+        } else {
+            let mut payload = vec![0; length as usize];
+            buf.read_exact(&mut payload)?;
+            let mut payload_cursor = Cursor::new(payload.as_slice());
+            Ok(OptionalNbt(simdnbt::owned::Nbt::azalea_read(
+                &mut payload_cursor,
+            )?))
+        }
+    }
+
+    fn azalea_write(&self, buf: &mut impl Write) -> io::Result<()> {
+        match &self.0 {
+            simdnbt::owned::Nbt::Some(_) => {
+                let mut payload = Vec::new();
+                self.0.azalea_write(&mut payload)?;
+                (payload.len() as u32).azalea_write_var(buf)?;
+                buf.write_all(&payload)?;
+            }
+            simdnbt::owned::Nbt::None => {
+                0_u32.azalea_write_var(buf)?;
+            }
+        }
+        Ok(())
+    }
+}
 
 pub const PROTOCOL_VERSION: i32 = 775;
 pub const VERSION_NAME: &str = "26.1.2";

--- a/azalea-protocol/tests/optional_nbt.rs
+++ b/azalea-protocol/tests/optional_nbt.rs
@@ -1,0 +1,99 @@
+use std::io::Cursor;
+
+use azalea_buf::{AzBuf, AzBufVar};
+use azalea_protocol::packets::{
+    OptionalNbt, game::s_custom_click_action::ServerboundCustomClickAction,
+};
+use azalea_registry::identifier::Identifier;
+use simdnbt::owned::{BaseNbt, Nbt, NbtCompound};
+
+fn nbt_with_byte() -> Nbt {
+    let mut compound = NbtCompound::new();
+    compound.insert("a", 1_i8);
+    Nbt::Some(BaseNbt::new("", compound))
+}
+
+fn dialog_probe_nbt() -> Nbt {
+    let mut compound = NbtCompound::new();
+    compound.insert("args", "");
+    compound.insert("cmd", "azaleatest:probe");
+    compound.insert("field", "x".repeat(60));
+    Nbt::Some(BaseNbt::new("", compound))
+}
+
+fn parse_hex_fixture(hex: &str) -> Vec<u8> {
+    hex.split_ascii_whitespace()
+        .map(|byte| u8::from_str_radix(byte, 16).expect("hex fixture should be valid"))
+        .collect()
+}
+
+#[test]
+fn optional_nbt_roundtrip_matches_vanilla_capture() {
+    let mut encoded = Vec::new();
+    OptionalNbt(nbt_with_byte())
+        .azalea_write(&mut encoded)
+        .expect("present NBT should encode");
+
+    assert_eq!(encoded[0], 7);
+    assert_eq!(
+        encoded,
+        include_bytes!("data/optional_nbt_present_minimal.bin")
+    );
+
+    let mut cursor = Cursor::new(encoded.as_slice());
+    let decoded =
+        OptionalNbt::azalea_read(&mut cursor).expect("present NBT should decode from fixture");
+    assert_eq!(decoded, OptionalNbt(nbt_with_byte()));
+
+    let mut absent = Vec::new();
+    OptionalNbt(Nbt::None)
+        .azalea_write(&mut absent)
+        .expect("absent NBT should encode");
+    assert_eq!(absent, include_bytes!("data/optional_nbt_absent.bin"));
+
+    let fixture = parse_hex_fixture(include_str!(
+        "data/optional_nbt_vanilla_dialog_probe.hex.txt"
+    ));
+    let mut cursor = Cursor::new(fixture.as_slice());
+    let decoded =
+        OptionalNbt::azalea_read(&mut cursor).expect("dialog payload fixture should decode");
+    assert!(decoded.0.contains("args"));
+    assert!(decoded.0.contains("cmd"));
+    assert!(decoded.0.contains("field"));
+}
+
+#[test]
+fn optional_nbt_present_prefix_is_varint_length_not_bool() {
+    let mut payload = Vec::new();
+    dialog_probe_nbt()
+        .azalea_write(&mut payload)
+        .expect("bare NBT should encode");
+
+    let id = Identifier::from("azaleatest:probe");
+    let mut id_bytes = Vec::new();
+    id.azalea_write(&mut id_bytes)
+        .expect("packet id should encode");
+
+    let mut encoded = Vec::new();
+    ServerboundCustomClickAction {
+        id,
+        payload: dialog_probe_nbt().into(),
+    }
+    .azalea_write(&mut encoded)
+    .expect("packet should encode");
+
+    let mut expected_prefix = Vec::new();
+    (payload.len() as u32)
+        .azalea_write_var(&mut expected_prefix)
+        .expect("payload length should encode as VarInt");
+
+    let prefix_start = id_bytes.len();
+    let prefix_end = prefix_start + expected_prefix.len();
+
+    assert_eq!(
+        &encoded[prefix_start..prefix_end],
+        expected_prefix.as_slice()
+    );
+    assert_ne!(encoded[prefix_start], 1);
+    assert_eq!(&encoded[prefix_end..], payload.as_slice());
+}


### PR DESCRIPTION
The serverbound `custom_click_action` payload is currently encoded as bare unnamed NBT, but vanilla expects a VarInt byte length followed by unnamed NBT (with `0` meaning absent). Empty payloads happen to round-trip because `Nbt::None` writes `0x00` and that's also the VarInt zero-length sentinel, which is probably why this hasn't surfaced before — any non-empty submission disconnects.

Repro on a vanilla 26.1.2 server with an OP'd offline user and a tiny `minecraft:notice` dialog datapack with a text input. Submitting the dialog from unpatched azalea:

```
nbtazaleaprobe lost connection: Internal Exception: io.netty.handler.codec.DecoderException:
java.io.IOException: Packet play/serverbound/minecraft:custom_click_action was larger than
I expected, found 145 bytes extra whilst reading packet serverbound/minecraft:custom_click_action
```

Outgoing payload after the action id, unpatched vs. patched:

```
unpatched: ... 10 61 7a 61 6c 65 61 74 65 73 74 3a 70 72 6f 62 65 0a 08 00 05 ...
patched:   ... 10 61 7a 61 6c 65 61 74 65 73 74 3a 70 72 6f 62 65 9c 01 0a 08 00 05 ...
```

`9c 01` is the VarInt for the 156-byte NBT payload that follows.

The fix adds an `OptionalNbt` newtype whose `AzBuf` impl reads/writes the VarInt-length framing, and switches both `s_custom_click_action.rs` (config + game) to use it.

Regression tests live in `azalea-protocol/tests/optional_nbt.rs` (minimal present payload, absent payload, vanilla-shaped dialog payload with `args` / `cmd` / `field` keys).

The first commit also contains a few mechanical clippy fixes in unrelated existing code — without them `cargo clippy -p azalea-protocol --all-targets -- -D warnings` doesn't pass on the base, so the new tests can't be gated on it cleanly. Happy to drop that commit if you'd rather it land separately.

One thing worth a second pair of eyes: I only found two packets that use this framing today. If you know of others that should switch to `OptionalNbt`, point me at them.
