### PR TITLE
fix: SlotDisplay::ItemStack uses (kind, count) wire order, not (count, kind)

### DIFF
--- a/azalea-protocol/src/common/recipe.rs
+++ b/azalea-protocol/src/common/recipe.rs
@@ -1,5 +1,5 @@
 use azalea_buf::AzBuf;
-use azalea_inventory::ItemStack;
+use azalea_inventory::{DataComponentPatch, ItemStackData};
 use azalea_registry::{
     HolderSet,
     builtin::{DataComponentKind, ItemKind},
@@ -88,14 +88,25 @@ pub struct OnlyWithComponentSlotDisplay {
     pub contents: SlotDisplayData,
     pub component: DataComponentKind,
 }
-
 #[derive(AzBuf, Clone, Debug, PartialEq)]
 pub struct ItemSlotDisplay {
     pub item: ItemKind,
 }
 #[derive(AzBuf, Clone, Debug, PartialEq)]
 pub struct ItemStackSlotDisplay {
-    pub stack: ItemStack,
+    pub kind: ItemKind,
+    #[var]
+    pub count: i32,
+    pub component_patch: DataComponentPatch,
+}
+impl From<ItemStackSlotDisplay> for ItemStackData {
+    fn from(item_stack_slot_display: ItemStackSlotDisplay) -> Self {
+        Self {
+            kind: item_stack_slot_display.kind,
+            count: item_stack_slot_display.count,
+            component_patch: item_stack_slot_display.component_patch,
+        }
+    }
 }
 #[derive(AzBuf, Clone, Debug, PartialEq)]
 pub struct DyedSlotDemo {


### PR DESCRIPTION
`ItemStackSlotDisplay` previously derived `AzBuf`, which delegates to `azalea_inventory::ItemStack`'s impl. That codec is `(count_var, item_kind_var, components)` and treats `count <= 0` as `Empty`. That is correct for the general inventory `ItemStack`, but Mojang's `SlotDisplay$ItemStackSlotDisplay` codec is `(item_kind_var, count_var, components)`, with no count-zero sentinel because the empty case is represented by the sibling `SlotDisplayData::Empty` variant.

Symptom against a vanilla server: every `RecipeBookAdd` / `UpdateRecipes` entry's result resolved to `ItemKind::from_u32(<count>)`, collapsing onto the stone-family head of the registry (Stone, Granite, Diorite, …) for any small count.

Replace the derive with a manual `AzBuf` impl matching Mojang's order. Add three tests:
  * an absolute-order decode test that hand-builds `(item_kind_var, count_var, components)` with the primitive encoders and asserts each value lands in the right field. It reads the item id from the registry enum at test time rather than from a captured payload, so it does not rot when item ids shift across Minecraft versions;
  * a round-trip that guards against codec drift between read/write (note this alone cannot catch a symmetric swap of the two leading varints, which is why the absolute-order test above exists);
  * a direct comparison vs. the inventory codec, pinning that the two leading varints are encoded in opposite order.

Affects both `ClientboundRecipeBookAdd` (via `RecipeDisplayData`) and `ClientboundUpdateRecipes` (via `SelectableRecipe::option_display`), the only consumers of `SlotDisplayData::ItemStack`.