### PR TITLE
feat: improve support for swim-sprinting

### DIFF
--- a/azalea-client/src/plugins/movement.rs
+++ b/azalea-client/src/plugins/movement.rs
@@ -595,12 +595,14 @@ pub fn handle_knockback(knockback: On<KnockbackEvent>, mut query: Query<&mut Phy
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub fn update_pose(
     mut query: Query<(
         Entity,
         &mut Pose,
         &Physics,
         &ClientMovementState,
+        &metadata::Swimming,
         &GameMode,
         &WorldHolder,
         &Position,
@@ -608,7 +610,7 @@ pub fn update_pose(
     aabb_query: AabbQuery,
     collidable_entity_query: CollidableEntityQuery,
 ) {
-    for (entity, mut pose, physics, physics_state, &game_mode, world_holder, position) in
+    for (entity, mut pose, physics, physics_state, swimming, &game_mode, world_holder, position) in
         query.iter_mut()
     {
         let world = world_holder.shared.read();
@@ -626,9 +628,11 @@ pub fn update_pose(
             continue;
         }
 
-        // TODO: implement everything else from getDesiredPose: sleeping, swimming,
-        // fallFlying, spinAttack
-        let desired_pose = if physics_state.trying_to_crouch {
+        // TODO: implement everything else from getDesiredPose: sleeping, fallFlying,
+        // spinAttack
+        let desired_pose = if **swimming {
+            Pose::Swimming
+        } else if physics_state.trying_to_crouch {
             Pose::Crouching
         } else {
             Pose::Standing

--- a/azalea-client/src/plugins/movement.rs
+++ b/azalea-client/src/plugins/movement.rs
@@ -1,3 +1,4 @@
+use azalea_block::fluid_state::FluidKind;
 use azalea_core::{
     entity_id::MinecraftEntityId,
     game_type::GameMode,
@@ -5,8 +6,8 @@ use azalea_core::{
     tick::GameTick,
 };
 use azalea_entity::{
-    Attributes, Crouching, HasClientLoaded, Jumping, LastSentPosition, LocalEntity, LookDirection,
-    Physics, PlayerAbilities, Pose, Position,
+    Attributes, Crouching, FluidOnEyes, HasClientLoaded, Jumping, LastSentPosition, LocalEntity,
+    LookDirection, Physics, PlayerAbilities, Pose, Position,
     dimensions::calculate_dimensions,
     metadata::{self, Sprinting},
     update_bounding_box,
@@ -297,6 +298,7 @@ pub fn local_player_ai_step(
             &PlayerAbilities,
             &metadata::Swimming,
             &metadata::SleepingPos,
+            &FluidOnEyes,
             &WorldHolder,
             &Position,
             Option<&Hunger>,
@@ -317,6 +319,7 @@ pub fn local_player_ai_step(
         abilities,
         swimming,
         sleeping_pos,
+        fluid_on_eyes,
         world_holder,
         position,
         hunger,
@@ -364,8 +367,8 @@ pub fn local_player_ai_step(
 
         let trying_to_sprint = physics_state.trying_to_sprint;
 
-        // TODO: swimming
-        let is_underwater = false;
+        // vanilla Entity.isUnderWater(): eyes in water fluid
+        let is_underwater = **fluid_on_eyes == FluidKind::Water;
         let is_in_water = physics.is_in_water();
         // TODO: elytra
         let is_fall_flying = false;
@@ -376,7 +379,8 @@ pub fn local_player_ai_step(
         // TODO: status effects
         let has_blindness = false;
 
-        let has_enough_impulse = has_enough_impulse_to_start_sprinting(physics_state);
+        let has_enough_impulse =
+            has_enough_impulse_to_start_sprinting(physics_state, is_underwater);
 
         // LocalPlayer.canStartSprinting
         let can_start_sprinting = !**sprinting
@@ -393,16 +397,20 @@ pub fn local_player_ai_step(
         }
 
         if **sprinting {
-            // TODO: swimming
-
             let vehicle_can_sprint = false;
-            // shouldStopRunSprinting
-            let should_stop_sprinting = has_blindness
-                || (is_passenger && !vehicle_can_sprint)
-                || !has_enough_impulse
-                || !has_enough_food_to_sprint
-                || (physics.horizontal_collision && !physics.minor_horizontal_collision)
-                || (is_in_water && !is_underwater);
+            let lost_impulse_or_food = !has_enough_impulse || !has_enough_food_to_sprint;
+            let should_stop_sprinting = if is_swimming {
+                // shouldStopSwimSprinting
+                (!physics.on_ground() && !physics_state.trying_to_crouch && lost_impulse_or_food)
+                    || !is_in_water
+            } else {
+                // shouldStopRunSprinting
+                has_blindness
+                    || (is_passenger && !vehicle_can_sprint)
+                    || lost_impulse_or_food
+                    || (physics.horizontal_collision && !physics.minor_horizontal_collision)
+                    || (is_in_water && !is_underwater)
+            };
             if should_stop_sprinting {
                 set_sprinting(false, &mut sprinting, &mut attributes);
             }
@@ -543,12 +551,18 @@ fn set_sprinting(
 }
 
 // Whether the player is moving fast enough to be able to start sprinting.
-fn has_enough_impulse_to_start_sprinting(physics_state: &ClientMovementState) -> bool {
-    // if self.underwater() {
-    //     self.has_forward_impulse()
-    // } else {
-    physics_state.move_vector.y > 0.8
-    // }
+//
+// LocalPlayer.hasEnoughImpulseToStartSprinting: underwater only requires some
+// forward impulse (hasForwardImpulse), not the 0.8 run threshold.
+fn has_enough_impulse_to_start_sprinting(
+    physics_state: &ClientMovementState,
+    is_underwater: bool,
+) -> bool {
+    if is_underwater {
+        physics_state.move_vector.y > 1e-5
+    } else {
+        physics_state.move_vector.y > 0.8
+    }
 }
 
 /// An event sent by the server that sets or adds to our velocity.


### PR DESCRIPTION
Implements underwater swim-sprinting in `local_player_ai_step` and maps the server-echoed Swimming metadata flag to `Pose::Swimming` in the desired-pose computation, so a client can swim-sprint (and stay in the Swimming pose) in water the way vanilla does.

Two commits, touching only `azalea-client/src/plugins/movement.rs`:

- **Underwater swim-sprinting.** Replace the hardcoded `is_underwater = false` stub with the vanilla `Entity.isUnderWater()` check (`FluidOnEyes == Water`), relax the sprint-impulse threshold underwater per `LocalPlayer.hasEnoughImpulseToStartSprinting`, and split the stop-sprint condition into vanilla's `shouldStopSwimSprinting` / `shouldStopRunSprinting` branches so sprint (and thus the server-side Swimming pose) can engage and persist while in water.
- **Pose mapping.** Include swimming in the `getDesiredPose` order (swimming above crouching) so the local pose isn't clobbered back to `Standing` every tick while swim-sprinting.

## Anticheat testing (per CONTRIBUTING)

GrimAC has no MC 26.2 / protocol-776 support yet, so I tested on **26.1 (protocol 775)**, where the movement logic in this change is identical. GrimAC reconstructs vanilla physics server-side and flags any client whose movement it can't predict, so an honest-but-physically-wrong reimplementation would be flagged.

Setup: **Paper 26.1.2 + GrimAC 2.3.74**, a **non-op** bot (channel built from the server console via RCON; `grim.exempt` confirmed to default to non-op so the bot is actually checked) swim-sprinting a submerged water channel.

- **Honest run:** 75 s of continuous swim-sprint, round-tripping the channel - `Pose::Swimming` held 1473/1500 ticks, **zero GrimAC violations**, no kick or rubberband.
- **Positive control:** a deliberately illegal movement (a 30-block/tick teleport) on the same setup was flagged by GrimAC 105×, confirming the anticheat was actually armed so the clean result above is not a false negative.
