### PR TITLE
feat: Added check for crouching when moving in Water

### DIFF
--- a/azalea-physics/src/lib.rs
+++ b/azalea-physics/src/lib.rs
@@ -9,25 +9,28 @@ pub mod travel;
 
 use std::collections::HashSet;
 
-use azalea_block::{BlockState, BlockTrait, fluid_state::FluidState, properties};
+use azalea_block::{fluid_state::FluidState, properties, BlockState, BlockTrait};
 use azalea_core::{
     math,
     position::{BlockPos, Vec3},
     tick::GameTick,
 };
 use azalea_entity::{
-    ActiveEffects, Attributes, EntityKindComponent, HasClientLoaded, Jumping, LocalEntity,
-    LookDirection, OnClimbable, Physics, Pose, Position, dimensions::EntityDimensions,
-    metadata::Sprinting, move_relative,
+    dimensions::EntityDimensions, metadata::Sprinting, move_relative, ActiveEffects, Attributes,
+    EntityKindComponent, HasClientLoaded, Jumping, LocalEntity, LookDirection, OnClimbable, Physics,
+    Pose, Position,
 };
 use azalea_registry::builtin::{BlockKind, EntityKind, MobEffect};
 use azalea_world::{World, WorldName, Worlds};
 use bevy_app::{App, Plugin, Update};
 use bevy_ecs::prelude::*;
 use clip::box_traverse_blocks;
-use collision::{BLOCK_SHAPE, BlockWithShape, VoxelShape, move_colliding};
+use collision::{move_colliding, BlockWithShape, VoxelShape, BLOCK_SHAPE};
 
-use crate::collision::{MoveCtx, entity_collisions::update_last_bounding_box};
+use crate::{
+    client_movement::ClientMovementState,
+    collision::{entity_collisions::update_last_bounding_box, MoveCtx},
+};
 
 /// A Bevy [`SystemSet`] for running physics that makes entities do things.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, SystemSet)]
@@ -73,6 +76,7 @@ pub fn ai_step(
             &ActiveEffects,
             &WorldName,
             &EntityKindComponent,
+            &ClientMovementState,
         ),
         (With<LocalEntity>, With<HasClientLoaded>),
     >,
@@ -87,6 +91,7 @@ pub fn ai_step(
         active_effects,
         world_name,
         entity_kind,
+        client_movement,
     ) in &mut query
     {
         let is_player = **entity_kind == EntityKind::Player;
@@ -121,6 +126,10 @@ pub fn ai_step(
         } else {
             physics.x_acceleration *= 0.98;
             physics.z_acceleration *= 0.98;
+        }
+
+        if client_movement.trying_to_crouch && physics.is_in_water() {
+            go_down_in_water(&mut physics);
         }
 
         if jumping == Some(&Jumping(true)) {
@@ -170,6 +179,10 @@ pub fn ai_step(
 
 fn jump_in_liquid(physics: &mut Physics) {
     physics.velocity.y += 0.04;
+}
+
+fn go_down_in_water(physics: &mut Physics) {
+    physics.velocity.y -= 0.04;
 }
 
 // in minecraft, this is done as part of aiStep immediately after travel


### PR DESCRIPTION
The bot now moves down as expected when crouching in water.
Its pretty much exactly like the minecraft implementation found in the LocalPlayer class.
Grim was also happy with it.