### PR TITLE
Improve performence of block trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,8 @@ dependencies = [
  "azalea-block-macros",
  "azalea-buf",
  "azalea-registry",
+ "criterion",
+ "rand 0.10.2",
 ]
 
 [[package]]

--- a/azalea-block/Cargo.toml
+++ b/azalea-block/Cargo.toml
@@ -11,5 +11,13 @@ azalea-block-macros.workspace = true
 azalea-buf.workspace = true
 azalea-registry.workspace = true
 
+[dev-dependencies]
+criterion.workspace = true
+rand.workspace = true
+
+[[bench]]
+name = "block"
+harness = false
+
 [lints]
 workspace = true

--- a/azalea-block/README.md
+++ b/azalea-block/README.md
@@ -28,7 +28,7 @@ let block_state: BlockState = BlockKind::Jukebox.into();
 
 ## `BlockTrait`
 
-The [`BlockTrait`] trait represents a type of a block. With [`BlockTrait`], you can get some extra things like the string block ID and some information about the block's behavior. Also, the structs that implement the trait contain the block attributes as fields so it's more convenient to get them. Note that this is often used as `Box<dyn BlockTrait>`.
+The [`BlockTrait`] trait represents a type of a block. With [`BlockTrait`], you can get some extra things like the string block ID and some information about the block's behavior. Also, the structs that implement the trait contain the block attributes as fields so it's more convenient to get them.
 If for some reason you don't want `BlockTrait`, set `default-features = false`.
 
 ```
@@ -39,7 +39,7 @@ let block = block_state.to_trait();
 ```
 # use azalea_block::{BlockTrait, BlockState};
 # let block_state: BlockState = azalea_registry::builtin::BlockKind::Jukebox.into();
-if let Some(jukebox) = Box::<dyn BlockTrait>::from(block_state).downcast_ref::<azalea_block::blocks::Jukebox>() {
+if let Some(jukebox) = block_state.to_trait().downcast_ref::<azalea_block::blocks::Jukebox>() {
     // ...
 }
 ```

--- a/azalea-block/README.md
+++ b/azalea-block/README.md
@@ -39,7 +39,7 @@ let block = block_state.to_trait();
 ```
 # use azalea_block::{BlockTrait, BlockState};
 # let block_state: BlockState = azalea_registry::builtin::BlockKind::Jukebox.into();
-if let Some(jukebox) = block_state.to_trait().downcast_ref::<azalea_block::blocks::Jukebox>() {
+if let Some(jukebox) = block_state.downcast_ref::<azalea_block::blocks::Jukebox>() {
     // ...
 }
 ```

--- a/azalea-block/README.md
+++ b/azalea-block/README.md
@@ -34,7 +34,7 @@ If for some reason you don't want `BlockTrait`, set `default-features = false`.
 ```
 # use azalea_block::{BlockTrait, BlockState};
 # let block_state = BlockState::from(azalea_registry::builtin::BlockKind::Jukebox);
-let block = Box::<dyn BlockTrait>::from(block_state);
+let block = block_state.to_trait();
 ```
 ```
 # use azalea_block::{BlockTrait, BlockState};

--- a/azalea-block/azalea-block-macros/src/lib.rs
+++ b/azalea-block/azalea-block-macros/src/lib.rs
@@ -139,6 +139,7 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as MakeBlockStates);
 
     let mut properties_map = HashMap::new();
+
     for property in &input.properties {
         let property_value_type = get_property_value_type(&property.data);
         let property_variant_types = get_property_variant_types(&property.data);
@@ -149,6 +150,7 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
 
     let mut block_state_enum_variants = quote! {};
     let mut block_structs = quote! {};
+    let mut block_statics = quote! {};
 
     let mut from_state_to_block_match = quote! {};
     let mut from_kind_to_block_match = quote! {};
@@ -264,6 +266,18 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
                 #block_name_pascal_case,
             });
             default_state_id = Some(state_id);
+
+            let static_name = Ident::new(
+                &format!("__BLOCK_STATE_{}_{}", block_struct_name, state_id).to_uppercase(),
+                proc_macro2::Span::call_site(),
+            );
+
+            block_statics.extend(quote! {
+                static #static_name: #block_struct_name = #block_struct_name {};
+            });
+
+            from_state_to_block_match.extend(quote! { &#static_name, });
+
             state_id += 1;
         }
         for combination in combinations_of(&block_properties_vec) {
@@ -331,6 +345,19 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
                 default_state_id = Some(state_id);
             }
 
+            let static_name = Ident::new(
+                &format!("__BLOCK_STATE_{}_{}", block_struct_name, state_id).to_uppercase(),
+                proc_macro2::Span::call_site(),
+            );
+
+            block_statics.extend(quote! {
+                static #static_name: #block_struct_name = #block_struct_name {
+                    #from_block_to_state_combination_match_inner
+                };
+            });
+
+            from_state_to_block_match.extend(quote! { &#static_name, });
+
             state_id += 1;
         }
 
@@ -358,6 +385,7 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
         //     }
         // }
         let mut from_state_to_block_inner = quote! {};
+
         let mut division: BlockStateIntegerRepr = 1;
         for i in (0..properties_with_name.len()).rev() {
             let PropertyWithNameAndDefault {
@@ -412,20 +440,6 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
         }
 
         let last_state_id = state_id - 1;
-        from_state_to_block_match.extend(if first_state_id == last_state_id {
-            quote! {
-                #first_state_id => {
-                    Box::new(#block_struct_name { #from_state_to_block_inner })
-                },
-            }
-        } else {
-            quote! {
-                #first_state_id..=#last_state_id => {
-                    let b = b - #first_state_id;
-                    Box::new(#block_struct_name { #from_state_to_block_inner })
-                },
-            }
-        });
 
         from_kind_to_block_match.extend(quote! {
             BlockKind::#block_name_pascal_case => Box::new(#block_struct_name::default()),
@@ -511,6 +525,9 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
 
         block_struct.extend(quote! {
             impl BlockTrait for #block_struct_name {
+                fn boxed(&self) -> Box<dyn BlockTrait>{
+                    Box::new(*self)
+                }
                 fn behavior(&self) -> BlockBehavior {
                     #block_behavior
                 }
@@ -523,6 +540,7 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
                 fn as_block_kind(&self) -> BlockKind {
                     BlockKind::#block_name_pascal_case
                 }
+
 
                 fn property_map(&self) -> std::collections::HashMap<&'static str, &'static str> {
                     let mut map = std::collections::HashMap::new();
@@ -559,6 +577,7 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
     }
 
     let last_state_id = state_id - 1;
+
     let mut generated = quote! {
         impl BlockState {
             /// The highest possible block state ID.
@@ -604,15 +623,20 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
 
             #block_structs
 
-            impl From<BlockState> for Box<dyn BlockTrait> {
+            #block_statics
+
+            static BLOCK_STATE_TABLE: &[&'static dyn BlockTrait; BlockState::MAX_STATE as usize + 1] = &[
+                #from_state_to_block_match
+            ];
+
+
+            impl From<BlockState> for &'static dyn BlockTrait {
                 fn from(block_state: BlockState) -> Self {
-                    let b = block_state.id();
-                    match b {
-                        #from_state_to_block_match
-                        _ => panic!("Invalid block state: {}", b),
-                    }
+                    let id = block_state.id() as usize;
+                    BLOCK_STATE_TABLE[id]
                 }
             }
+
             impl From<BlockKind> for Box<dyn BlockTrait> {
                 fn from(block: BlockKind) -> Self {
                     match block {
@@ -652,3 +676,4 @@ fn name_to_ident(name: &str) -> Ident {
     };
     Ident::new(ident_str, proc_macro2::Span::call_site())
 }
+

--- a/azalea-block/azalea-block-macros/src/lib.rs
+++ b/azalea-block/azalea-block-macros/src/lib.rs
@@ -630,10 +630,34 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
             ];
 
 
+            /// Convert a [`BlockState`] to a [`&'static dyn BlockTrait`].
+            ///
+            /// # Panics
+            ///
+            /// Panics if the [`BlockState`] is invalid.
+            #[inline]
+            #[must_use]
+            pub const fn blockstate_to_blocktrait(state: BlockState) -> &'static dyn BlockTrait {
+                BLOCK_STATE_TABLE[state.id() as usize]
+            }
+
+            /// Try to convert a [`BlockState`] to a [`&'static dyn BlockTrait`].
+            ///
+            /// Returns `None` if the [`BlockState`] is invalid.
+            #[must_use]
+            pub const fn try_blockstate_to_blocktrait(state: BlockState) -> Option<&'static dyn BlockTrait> {
+                let state_id: usize = state.id() as usize;
+                if state_id < BLOCK_STATE_TABLE.len() {
+                    Some(BLOCK_STATE_TABLE[state_id])
+                } else {
+                    None
+                }
+            }
+
             impl From<BlockState> for &'static dyn BlockTrait {
+                #[inline]
                 fn from(block_state: BlockState) -> Self {
-                    let id = block_state.id() as usize;
-                    BLOCK_STATE_TABLE[id]
+                    blockstate_to_blocktrait(block_state)
                 }
             }
 
@@ -676,4 +700,3 @@ fn name_to_ident(name: &str) -> Ident {
     };
     Ident::new(ident_str, proc_macro2::Span::call_site())
 }
-

--- a/azalea-block/azalea-block-macros/src/lib.rs
+++ b/azalea-block/azalea-block-macros/src/lib.rs
@@ -631,27 +631,10 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
 
 
             /// Convert a [`BlockState`] to a [`&'static dyn BlockTrait`].
-            ///
-            /// # Panics
-            ///
-            /// Panics if the [`BlockState`] is invalid.
             #[inline]
             #[must_use]
             pub const fn blockstate_to_blocktrait(state: BlockState) -> &'static dyn BlockTrait {
                 BLOCK_STATE_TABLE[state.id() as usize]
-            }
-
-            /// Try to convert a [`BlockState`] to a [`&'static dyn BlockTrait`].
-            ///
-            /// Returns `None` if the [`BlockState`] is invalid.
-            #[must_use]
-            pub const fn try_blockstate_to_blocktrait(state: BlockState) -> Option<&'static dyn BlockTrait> {
-                let state_id: usize = state.id() as usize;
-                if state_id < BLOCK_STATE_TABLE.len() {
-                    Some(BLOCK_STATE_TABLE[state_id])
-                } else {
-                    None
-                }
             }
 
             impl From<BlockState> for &'static dyn BlockTrait {

--- a/azalea-block/benches/block.rs
+++ b/azalea-block/benches/block.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 
 use azalea_block::{BlockState, BlockTrait};
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 
 fn bench_block(c: &mut Criterion) {
     c.bench_function("Box<dyn BlockTrait> from BlockState", |b| {
@@ -17,8 +17,7 @@ fn bench_block(c: &mut Criterion) {
             },
             |blocks| {
                 for block in blocks {
-                    let boxed: Box<dyn BlockTrait> = block.to_trait().boxed();
-                    black_box(boxed);
+                    black_box(block.boxed());
                 }
             },
             BatchSize::LargeInput,

--- a/azalea-block/benches/block.rs
+++ b/azalea-block/benches/block.rs
@@ -1,0 +1,51 @@
+use std::hint::black_box;
+
+use azalea_block::{BlockState, BlockTrait};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+
+fn bench_block(c: &mut Criterion) {
+    c.bench_function("Box<dyn BlockTrait> from BlockState", |b| {
+        b.iter_batched(
+            || {
+                let mut blocks = Vec::with_capacity(1024);
+                for _ in 0..1024 {
+                    let id = rand::random_range(0..=BlockState::MAX_STATE);
+                    let block = BlockState::try_from(id).unwrap();
+                    blocks.push(block);
+                }
+                blocks
+            },
+            |blocks| {
+                for block in blocks {
+                    let boxed: Box<dyn BlockTrait> = block.to_trait().boxed();
+                    black_box(boxed);
+                }
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    c.bench_function("&dyn BlockTrait from BlockState", |b| {
+        b.iter_batched(
+            || {
+                let mut blocks = Vec::with_capacity(1024);
+                for _ in 0..1024 {
+                    let id = rand::random_range(0..=BlockState::MAX_STATE);
+                    let block = BlockState::try_from(id).unwrap();
+                    blocks.push(block);
+                }
+                blocks
+            },
+            |blocks| {
+                for block in blocks {
+                    let r: &dyn BlockTrait = block.to_trait();
+                    black_box(r);
+                }
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+criterion_group!(benches, bench_block);
+criterion_main!(benches);

--- a/azalea-block/src/block_state.rs
+++ b/azalea-block/src/block_state.rs
@@ -46,6 +46,10 @@ impl BlockState {
         Self { id }
     }
 
+    pub fn to_trait(self) -> &'static dyn BlockTrait {
+        From::from(self)
+    }
+
     /// Whether the block state is possible to exist in vanilla Minecraft.
     ///
     /// It's equivalent to checking that the state ID is not greater than
@@ -137,7 +141,7 @@ impl Debug for BlockState {
             f,
             "BlockState(id: {}, {:?})",
             self.id,
-            Box::<dyn BlockTrait>::from(*self)
+            self.to_trait()
         )
     }
 }
@@ -165,11 +169,10 @@ mod tests {
 
     #[test]
     fn test_from_blockstate() {
-        let block: Box<dyn BlockTrait> = Box::<dyn BlockTrait>::from(BlockState::AIR);
+        let block = BlockState::AIR.to_trait();
         assert_eq!(block.id(), "air");
 
-        let block: Box<dyn BlockTrait> =
-            Box::<dyn BlockTrait>::from(BlockState::from(BlockKind::FloweringAzalea));
+        let block = BlockState::from(BlockKind::FloweringAzalea).to_trait();
         assert_eq!(block.id(), "flowering_azalea");
     }
 

--- a/azalea-block/src/block_state.rs
+++ b/azalea-block/src/block_state.rs
@@ -2,6 +2,7 @@ use std::{
     fmt::{self, Debug},
     hint::assert_unchecked,
     io::{self, Cursor, Write},
+    ops::Deref,
 };
 
 use azalea_buf::{AzBuf, AzBufVar, BufReadError};
@@ -31,13 +32,18 @@ pub struct BlockState {
 }
 
 impl BlockState {
-    /// A shortcut for getting the air block state, since it always has an ID of
-    /// 0.
+    /// A shortcut for getting air, since it always has an ID of `0`.
+    ///
+    /// # Note
     ///
     /// This does not include the other types of air like cave air.
     pub const AIR: BlockState = BlockState { id: 0 };
 
-    /// Create a new BlockState and panic if the block is not a valid state.
+    /// Create a new [`BlockState`]
+    ///
+    /// # Panics
+    ///
+    /// Panics if the block is not a valid state.
     ///
     /// You should probably use [`BlockState::try_from`] instead.
     #[inline]
@@ -46,8 +52,11 @@ impl BlockState {
         Self { id }
     }
 
-    pub fn to_trait(self) -> &'static dyn BlockTrait {
-        From::from(self)
+    /// Convert the [`BlockState`] into a [`&'static dyn BlockTrait`].
+    #[inline]
+    #[must_use]
+    pub const fn to_trait(self) -> &'static dyn BlockTrait {
+        crate::generated::blocks::blockstate_to_blocktrait(self)
     }
 
     /// Whether the block state is possible to exist in vanilla Minecraft.
@@ -80,6 +89,15 @@ impl BlockState {
         unsafe { assert_unchecked(Self::is_valid_state(self.id)) };
 
         self.id
+    }
+}
+
+impl Deref for BlockState {
+    type Target = dyn BlockTrait;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.to_trait()
     }
 }
 
@@ -137,12 +155,7 @@ impl AzBuf for BlockState {
 
 impl Debug for BlockState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "BlockState(id: {}, {:?})",
-            self.id,
-            self.to_trait()
-        )
+        write!(f, "BlockState(id: {}, {:?})", self.id, self.to_trait())
     }
 }
 

--- a/azalea-block/src/lib.rs
+++ b/azalea-block/src/lib.rs
@@ -19,7 +19,9 @@ pub use range::BlockStates;
 /// A trait that's implemented on block structs.
 ///
 /// See the [azalea_block documentation](crate) for details.
-pub trait BlockTrait: Debug + Any {
+pub trait BlockTrait: Debug + Any + Send + Sync {
+    fn boxed(&self) -> Box<dyn BlockTrait>;
+
     fn behavior(&self) -> BlockBehavior;
     /// Get the Minecraft string ID for this block.
     ///
@@ -95,7 +97,7 @@ mod tests {
             waterlogged: false,
         };
         let block_state = block.as_block_state();
-        let block_from_state = Box::<dyn BlockTrait>::from(block_state);
+        let block_from_state = block_state.to_trait();
         let block_from_state = *block_from_state
             .downcast_ref::<crate::blocks::OakTrapdoor>()
             .unwrap();

--- a/azalea-block/src/lib.rs
+++ b/azalea-block/src/lib.rs
@@ -20,23 +20,34 @@ pub use range::BlockStates;
 ///
 /// See the [azalea_block documentation](crate) for details.
 pub trait BlockTrait: Debug + Any + Send + Sync {
+    /// Convert the block struct to a boxed trait object.
+    #[must_use]
     fn boxed(&self) -> Box<dyn BlockTrait>;
 
+    /// Get the [`BlockBehavior`] of this block.
+    #[must_use]
     fn behavior(&self) -> BlockBehavior;
+
     /// Get the Minecraft string ID for this block.
     ///
     /// For example, `stone` or `grass_block`.
+    #[must_use]
     fn id(&self) -> &'static str;
+
     /// Convert the block struct to a [`BlockState`].
     ///
     /// This is a lossless conversion, as [`BlockState`] also contains state
     /// data.
+    #[must_use]
     fn as_block_state(&self) -> BlockState;
+
     /// Convert the block struct to a [`BlockKind`].
     ///
     /// This is a lossy conversion, as [`BlockKind`] doesn't contain any state
     /// data.
+    #[must_use]
     fn as_block_kind(&self) -> BlockKind;
+
     #[deprecated = "renamed to as_block_kind"]
     #[doc(hidden)]
     fn as_registry_block(&self) -> BlockKind {
@@ -48,14 +59,18 @@ pub trait BlockTrait: Debug + Any + Send + Sync {
     ///
     /// Consider using [`Self::get_property`] if you only need a single
     /// property.
+    #[must_use]
     fn property_map(&self) -> HashMap<&'static str, &'static str>;
+
     /// Get a property's value as a string by its name, or `None` if the block
     /// has no property with that name.
     ///
     /// To get all properties, you may use [`Self::property_map`].
     ///
     /// To set a property, use [`Self::set_property`].
+    #[must_use]
     fn get_property(&self, name: &str) -> Option<&'static str>;
+
     /// Update a property on this block, with the name and value being strings.
     ///
     /// Returns `Ok(())`, if the property name and value are valid, otherwise it
@@ -97,8 +112,7 @@ mod tests {
             waterlogged: false,
         };
         let block_state = block.as_block_state();
-        let block_from_state = block_state.to_trait();
-        let block_from_state = *block_from_state
+        let block_from_state = *block_state
             .downcast_ref::<crate::blocks::OakTrapdoor>()
             .unwrap();
         assert_eq!(block, block_from_state);

--- a/azalea-client/src/plugins/mining.rs
+++ b/azalea-client/src/plugins/mining.rs
@@ -1,4 +1,4 @@
-use azalea_block::{BlockState, BlockTrait, fluid_state::FluidState};
+use azalea_block::{BlockState, fluid_state::FluidState};
 use azalea_core::{direction::Direction, game_type::GameMode, position::BlockPos, tick::GameTick};
 use azalea_entity::{
     ActiveEffects, Attributes, FluidOnEyes, Physics, PlayerAbilities, Position,
@@ -333,13 +333,11 @@ pub fn handle_mining_queued(
                 });
             }
 
-            let block = target_block_state.to_trait();
-
             let held_item = inventory.held_item();
 
             if block_is_solid
                 && get_mine_progress(
-                    block,
+                    &*target_block_state,
                     held_item,
                     fluid_on_eyes,
                     physics,

--- a/azalea-client/src/plugins/mining.rs
+++ b/azalea-client/src/plugins/mining.rs
@@ -333,13 +333,13 @@ pub fn handle_mining_queued(
                 });
             }
 
-            let block = Box::<dyn BlockTrait>::from(target_block_state);
+            let block = target_block_state.to_trait();
 
             let held_item = inventory.held_item();
 
             if block_is_solid
                 && get_mine_progress(
-                    block.as_ref(),
+                    block,
                     held_item,
                     fluid_on_eyes,
                     physics,
@@ -652,9 +652,9 @@ pub fn continue_mining_block(
                 commands.entity(entity).remove::<Mining>();
                 continue;
             }
-            let block = Box::<dyn BlockTrait>::from(target_block_state);
+            let block = target_block_state.to_trait();
             **mine_progress += get_mine_progress(
-                block.as_ref(),
+                block,
                 current_mining_item,
                 fluid_on_eyes,
                 physics,

--- a/azalea-entity/src/plugin/mod.rs
+++ b/azalea-entity/src/plugin/mod.rs
@@ -4,7 +4,7 @@ pub mod indexing;
 
 use std::collections::HashSet;
 
-use azalea_block::{BlockState, BlockTrait, fluid_state::FluidKind, properties};
+use azalea_block::{BlockState, fluid_state::FluidKind, properties};
 use azalea_core::{
     entity_id::MinecraftEntityId,
     game_type::GameMode,
@@ -143,13 +143,12 @@ pub fn update_on_climbable(
         let world = world.read();
 
         let block_pos = BlockPos::from(position);
-        let block_state_at_feet = world.get_block_state(block_pos).unwrap_or_default();
-        let block_at_feet = block_state_at_feet.to_trait();
+        let block_at_feet = world.get_block_state(block_pos).unwrap_or_default();
         let registry_block_at_feet = block_at_feet.as_block_kind();
 
         **on_climbable = tags::blocks::CLIMBABLE.contains(&registry_block_at_feet)
             || (tags::blocks::TRAPDOORS.contains(&registry_block_at_feet)
-                && is_trapdoor_usable_as_ladder(block_state_at_feet, block_pos, &world));
+                && is_trapdoor_usable_as_ladder(block_at_feet, block_pos, &world));
     }
 }
 

--- a/azalea-entity/src/plugin/mod.rs
+++ b/azalea-entity/src/plugin/mod.rs
@@ -144,7 +144,7 @@ pub fn update_on_climbable(
 
         let block_pos = BlockPos::from(position);
         let block_state_at_feet = world.get_block_state(block_pos).unwrap_or_default();
-        let block_at_feet = Box::<dyn BlockTrait>::from(block_state_at_feet);
+        let block_at_feet = block_state_at_feet.to_trait();
         let registry_block_at_feet = block_at_feet.as_block_kind();
 
         **on_climbable = tags::blocks::CLIMBABLE.contains(&registry_block_at_feet)

--- a/azalea-physics/src/collision/mod.rs
+++ b/azalea-physics/src/collision/mod.rs
@@ -8,7 +8,7 @@ pub mod world_collisions;
 
 use std::{ops::Add, sync::LazyLock};
 
-use azalea_block::{BlockState, BlockTrait, fluid_state::FluidState};
+use azalea_block::{BlockState, fluid_state::FluidState};
 use azalea_core::{
     aabb::Aabb,
     direction::Axis,
@@ -494,8 +494,7 @@ pub fn legacy_blocks_motion(block: BlockState) -> bool {
 
 pub fn legacy_calculate_solid(block: BlockState) -> bool {
     // force_solid has to be checked before anything else
-    let block_trait = block.to_trait();
-    if let Some(solid) = block_trait.behavior().force_solid {
+    if let Some(solid) = block.behavior().force_solid {
         return solid;
     }
 

--- a/azalea-physics/src/collision/mod.rs
+++ b/azalea-physics/src/collision/mod.rs
@@ -494,7 +494,7 @@ pub fn legacy_blocks_motion(block: BlockState) -> bool {
 
 pub fn legacy_calculate_solid(block: BlockState) -> bool {
     // force_solid has to be checked before anything else
-    let block_trait = Box::<dyn BlockTrait>::from(block);
+    let block_trait = block.to_trait();
     if let Some(solid) = block_trait.behavior().force_solid {
         return solid;
     }

--- a/azalea-physics/src/lib.rs
+++ b/azalea-physics/src/lib.rs
@@ -508,7 +508,7 @@ fn block_jump_factor(world: &World, position: Position) -> f32 {
         .get_block_state(get_block_pos_below_that_affects_movement(position));
 
     let block_at_pos_jump_factor = if let Some(block) = block_at_pos {
-        Box::<dyn BlockTrait>::from(block).behavior().jump_factor
+        block.to_trait().behavior().jump_factor
     } else {
         1.
     };
@@ -517,7 +517,7 @@ fn block_jump_factor(world: &World, position: Position) -> f32 {
     }
 
     if let Some(block) = block_below {
-        Box::<dyn BlockTrait>::from(block).behavior().jump_factor
+        block.to_trait().behavior().jump_factor
     } else {
         1.
     }

--- a/azalea-physics/src/lib.rs
+++ b/azalea-physics/src/lib.rs
@@ -9,7 +9,7 @@ pub mod travel;
 
 use std::collections::HashSet;
 
-use azalea_block::{BlockState, BlockTrait, fluid_state::FluidState, properties};
+use azalea_block::{BlockState, fluid_state::FluidState, properties};
 use azalea_core::{
     math,
     position::{BlockPos, Vec3},
@@ -508,7 +508,7 @@ fn block_jump_factor(world: &World, position: Position) -> f32 {
         .get_block_state(get_block_pos_below_that_affects_movement(position));
 
     let block_at_pos_jump_factor = if let Some(block) = block_at_pos {
-        block.to_trait().behavior().jump_factor
+        block.behavior().jump_factor
     } else {
         1.
     };
@@ -517,7 +517,7 @@ fn block_jump_factor(world: &World, position: Position) -> f32 {
     }
 
     if let Some(block) = block_below {
-        block.to_trait().behavior().jump_factor
+        block.behavior().jump_factor
     } else {
         1.
     }

--- a/azalea-physics/src/travel.rs
+++ b/azalea-physics/src/travel.rs
@@ -110,7 +110,7 @@ fn travel_in_air(ctx: &mut MoveCtx) {
         .chunks
         .get_block_state(block_pos_below)
         .unwrap_or(BlockState::AIR);
-    let block_below: Box<dyn BlockTrait> = block_state_below.into();
+    let block_below = block_state_below.to_trait();
     let block_friction = block_below.behavior().friction;
 
     let inertia = if ctx.physics.on_ground() {

--- a/azalea-physics/src/travel.rs
+++ b/azalea-physics/src/travel.rs
@@ -1,4 +1,4 @@
-use azalea_block::{BlockState, BlockTrait, fluid_state::FluidState};
+use azalea_block::{BlockState, fluid_state::FluidState};
 use azalea_core::{
     aabb::Aabb,
     position::{BlockPos, Vec3},
@@ -105,14 +105,13 @@ fn travel_in_air(ctx: &mut MoveCtx) {
 
     let block_pos_below = get_block_pos_below_that_affects_movement(*ctx.position);
 
-    let block_state_below = ctx
+    let block_below = ctx
         .world
         .chunks
         .get_block_state(block_pos_below)
         .unwrap_or(BlockState::AIR);
-    let block_below = block_state_below.to_trait();
-    let block_friction = block_below.behavior().friction;
 
+    let block_friction = block_below.behavior().friction;
     let inertia = if ctx.physics.on_ground() {
         block_friction * 0.91
     } else {

--- a/azalea/src/auto_tool.rs
+++ b/azalea/src/auto_tool.rs
@@ -1,4 +1,4 @@
-use azalea_block::{BlockState, BlockTrait, fluid_state::FluidKind};
+use azalea_block::{BlockState, fluid_state::FluidKind};
 use azalea_core::position::BlockPos;
 use azalea_entity::{ActiveEffects, Attributes, FluidOnEyes, Physics, inventory::Inventory};
 use azalea_inventory::{ItemStack, Menu, components};
@@ -81,7 +81,7 @@ pub fn accurate_best_tool_in_hotbar_for_block(
     let mut best_speed = 0.;
     let mut best_slot = None;
 
-    let block = Box::<dyn BlockTrait>::from(block);
+    let block = block.to_trait();
     let registry_block = block.as_block_kind();
 
     if matches!(registry_block, BlockKind::Water | BlockKind::Lava) {
@@ -98,7 +98,7 @@ pub fn accurate_best_tool_in_hotbar_for_block(
         match item_stack_data {
             ItemStack::Empty => {
                 this_item_speed = Some(azalea_entity::mining::get_mine_progress(
-                    block.as_ref(),
+                    block,
                     &ItemStack::Empty,
                     fluid_on_eyes,
                     physics,
@@ -111,7 +111,7 @@ pub fn accurate_best_tool_in_hotbar_for_block(
                 // data yet
                 if !item_stack.component_patch.has::<components::Damage>() {
                     this_item_speed = Some(azalea_entity::mining::get_mine_progress(
-                        block.as_ref(),
+                        block,
                         item_stack_data,
                         fluid_on_eyes,
                         physics,
@@ -135,7 +135,7 @@ pub fn accurate_best_tool_in_hotbar_for_block(
     for (i, item_stack) in hotbar_slots.iter().enumerate() {
         if item_stack.is_present() {
             let this_item_speed = azalea_entity::mining::get_mine_progress(
-                block.as_ref(),
+                block,
                 item_stack,
                 fluid_on_eyes,
                 physics,

--- a/azalea/src/pathfinder/execute/mod.rs
+++ b/azalea/src/pathfinder/execute/mod.rs
@@ -3,7 +3,7 @@ pub mod simulation;
 
 use std::{cmp, time::Duration};
 
-use azalea_block::{BlockState, BlockTrait};
+use azalea_block::BlockState;
 use azalea_client::{
     StartSprintEvent, StartWalkEvent,
     local_player::WorldHolder,
@@ -169,14 +169,14 @@ pub fn check_node_reached(
 
                     let block_pos_below = get_block_pos_below_that_affects_movement(*position);
 
-                    let block_state_below = {
+                    let block_below = {
                         let world = world.read();
                         world
                             .chunks
                             .get_block_state(block_pos_below)
                             .unwrap_or(BlockState::AIR)
                     };
-                    let block_below = block_state_below.to_trait();
+
                     // friction for normal blocks is 0.6, for ice it's 0.98
                     let block_friction = block_below.behavior().friction as f64;
 

--- a/azalea/src/pathfinder/execute/mod.rs
+++ b/azalea/src/pathfinder/execute/mod.rs
@@ -176,7 +176,7 @@ pub fn check_node_reached(
                             .get_block_state(block_pos_below)
                             .unwrap_or(BlockState::AIR)
                     };
-                    let block_below: Box<dyn BlockTrait> = block_state_below.into();
+                    let block_below = block_state_below.to_trait();
                     // friction for normal blocks is 0.6, for ice it's 0.98
                     let block_friction = block_below.behavior().friction as f64;
 


### PR DESCRIPTION
## Description

Optimizes the conversion from `BlockState` to `BlockTrait` by replacing the monster match statment with a static table of `&'static dyn BlockTrait`.

* Adds `BlockState::to_trait()` for easy reference conversion.
* Adds a fallback method on `BlockTrait` to get a `Box<dyn BlockTrait>` when ownership is required.
* Adds benchmarks to track conversion performance.

## Benchmarks

*Note: These benchmarks use a randomized selection of blocks. Real-world performance may vary depending on cache locality and access patterns.*

```text
&dyn BlockTrait (Reference)
  Before: 390.14 µs  ->  After: 1.2546 µs  (-99.68% / ~310x faster)

Box<dyn BlockTrait> (Heap)
  Before: 396.05 µs  ->  After: 41.820 µs  (-89.44% / ~9.5x faster)

```

## Binary Size Impact

The file size of the benchmark binary increased by **7 MB** due to the addition of the static table. Note that this impact has only been measured on the standalone benchmark program and has not yet been tested on a full Azalea build.

## AI Usage
AI was used to write the benchmark code and the pr description, all other code was written by hand.