### PR TITLE
Add `ArcSwap` dependency, no longer lock when accessing `PartialChunkStorage`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,7 +432,7 @@ dependencies = [
  "cfb8",
  "criterion",
  "md-5 0.11.0",
- "num-bigint 0.5.0",
+ "num-bigint 0.5.1",
  "rand 0.10.2",
  "rand_core 0.10.1",
  "rsa",
@@ -585,6 +594,7 @@ dependencies = [
 name = "azalea-world"
 version = "0.16.0+mc26.2"
 dependencies = [
+ "arc-swap",
  "azalea-block",
  "azalea-buf",
  "azalea-core",
@@ -915,18 +925,18 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -941,9 +951,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -962,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1259,18 +1269,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1278,27 +1288,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1377,9 +1387,9 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -1387,12 +1397,11 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1409,9 +1418,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -1784,28 +1793,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2226,9 +2223,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -2240,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2300,11 +2297,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -2399,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minecraft_folder_path"
@@ -2492,7 +2489,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint 0.4.7",
+ "num-bigint 0.4.8",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -2502,9 +2499,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2512,9 +2509,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7032fbb7ef662c18e806aa75b311f68ddf5c94e8fc62832c0039d79095ab6abf"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2550,11 +2547,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2565,7 +2561,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint 0.4.7",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
@@ -2802,28 +2798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,15 +2828,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2876,16 +2851,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2896,12 +2871,6 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -2917,23 +2886,13 @@ checksum = "59ffec9df464013295b499298811e6a3de31bf8128092135826517db12dee601"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2958,16 +2917,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2978,18 +2927,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -3028,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3040,9 +2989,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3139,15 +3088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3e9243a1f8b312c5535c09de102cc061416515201b194ee4f0a9a76da20ebf4"
 dependencies = [
  "num",
- "rand 0.8.6",
+ "rand 0.8.7",
  "simple_asn1",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -3241,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -3480,7 +3429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb4ea60fb301dc81dfc113df680571045d375ab7345d171c5dc7d7e13107a80"
 dependencies = [
  "chrono",
- "num-bigint 0.4.7",
+ "num-bigint 0.4.8",
  "num-traits",
  "thiserror 1.0.69",
 ]
@@ -3527,9 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "socks5-impl"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378b73f34c3f2ad440310f40bf72574c76c3b72189f4d6c4180f3189884bf3a0"
+checksum = "6a3c6b739c6e39978fda237a14ffa14c88b97b665b741abd88f23bafa14e9c75"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3676,9 +3625,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -3705,9 +3654,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4056,15 +4005,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4253,16 +4193,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4280,31 +4211,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -4314,22 +4228,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4338,22 +4240,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4362,22 +4252,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4386,22 +4264,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -4411,12 +4277,6 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -4449,18 +4309,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4529,9 +4389,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ repository = "https://github.com/azalea-rs/azalea"
 
 [workspace.dependencies]
 aes = "0.9.1"
+arc-swap = "1.9.2"
 async-compat = "0.2.5"
 base64 = "0.22.1"
 bevy_app = "0.19.0"

--- a/azalea-client/src/local_player.rs
+++ b/azalea-client/src/local_player.rs
@@ -164,10 +164,10 @@ impl WorldHolder {
     pub fn reset(&mut self) {
         let registries = self.shared.read().registries.clone();
 
-        *self.shared.write() = World {
+        self.shared = Arc::new(RwLock::new(World {
             registries,
             ..World::default()
-        };
+        }));
 
         self.partial.reset();
     }

--- a/azalea-client/src/local_player.rs
+++ b/azalea-client/src/local_player.rs
@@ -22,7 +22,7 @@ use crate::{ClientInformation, player::PlayerInfo};
 pub struct WorldHolder {
     /// The slice of the world that this client actually has loaded, based on
     /// its render distance.
-    pub partial: Arc<RwLock<PartialWorld>>,
+    pub partial: Arc<PartialWorld>,
     /// The combined [`PartialWorld`]s of all clients in the same world.
     ///
     /// The distinction between this and `partial` is mostly only relevant if
@@ -30,6 +30,8 @@ pub struct WorldHolder {
     /// the shared world.
     pub shared: Arc<RwLock<World>>,
 }
+
+#[doc(hidden)]
 #[deprecated = "renamed to `WorldHolder`."]
 pub type InstanceHolder = WorldHolder;
 
@@ -146,12 +148,12 @@ impl WorldHolder {
 
         WorldHolder {
             shared,
-            partial: Arc::new(RwLock::new(PartialWorld::new(
+            partial: Arc::new(PartialWorld::new(
                 azalea_world::chunk::calculate_chunk_storage_range(
                     client_information.view_distance.into(),
                 ),
                 Some(entity),
-            ))),
+            )),
         }
     }
 
@@ -162,12 +164,11 @@ impl WorldHolder {
     pub fn reset(&mut self) {
         let registries = self.shared.read().registries.clone();
 
-        let new_world = World {
+        *self.shared.write() = World {
             registries,
-            ..Default::default()
+            ..World::default()
         };
-        self.shared = Arc::new(RwLock::new(new_world));
 
-        self.partial.write().reset();
+        self.partial.reset();
     }
 }

--- a/azalea-client/src/plugins/chunks.rs
+++ b/azalea-client/src/plugins/chunks.rs
@@ -74,7 +74,7 @@ pub fn handle_receive_chunk_event(
         let local_player = query.get_mut(event.entity).unwrap();
 
         let mut world = local_player.shared.write();
-        let mut partial_world = local_player.partial.write();
+        let partial_world = &local_player.partial;
 
         // OPTIMIZATION: if we already know about the chunk from the shared world (and
         // not ourselves), then we don't need to parse it again. This is only used when

--- a/azalea-client/src/plugins/packet/game/mod.rs
+++ b/azalea-client/src/plugins/packet/game/mod.rs
@@ -282,14 +282,14 @@ impl GamePacketHandler<'_> {
                 // set the partial world to an empty world (when we add chunks or entities those
                 // will be in the `worlds`)
 
-                *world_holder.partial.write() = PartialWorld::new(
+                world_holder.partial = Arc::new(PartialWorld::new(
                     azalea_world::chunk::calculate_chunk_storage_range(
                         client_information.view_distance.into(),
                     ),
                     // this argument makes it so other clients don't update this player entity in a
                     // shared world
                     Some(self.player),
-                );
+                ));
                 {
                     let client_registries = world_holder.shared.read().registries.clone();
                     let shared_registries = &mut weak_world.write().registries;
@@ -538,7 +538,7 @@ impl GamePacketHandler<'_> {
 
         as_system::<Query<&WorldHolder>>(self.ecs, |mut query| {
             let world_holder = query.get_mut(self.player).unwrap();
-            let mut partial_world = world_holder.partial.write();
+            let partial_world = &world_holder.partial;
 
             partial_world
                 .chunks
@@ -747,7 +747,7 @@ impl GamePacketHandler<'_> {
             // multiple times when in swarms
             if should_apply_entity_update(
                 &mut commands,
-                &mut world_holder.partial.write(),
+                &world_holder.partial,
                 entity,
                 entity_update_query,
             ) {
@@ -1087,7 +1087,7 @@ impl GamePacketHandler<'_> {
 
             if !should_apply_entity_update(
                 &mut commands,
-                &mut world_holder.partial.write(),
+                &world_holder.partial,
                 entity,
                 entity_update_query,
             ) {
@@ -1238,8 +1238,7 @@ impl GamePacketHandler<'_> {
         as_system::<Query<&WorldHolder>>(self.ecs, |mut query| {
             let local_player = query.get_mut(self.player).unwrap();
 
-            let mut partial_world = local_player.partial.write();
-
+            let partial_world = &local_player.partial;
             partial_world.chunks.limited_set(&p.pos, None);
         });
     }
@@ -1328,7 +1327,7 @@ impl GamePacketHandler<'_> {
 
             if !should_apply_entity_update(
                 &mut commands,
-                &mut world_holder.partial.write(),
+                &world_holder.partial,
                 entity,
                 entity_update_query,
             ) {
@@ -1420,12 +1419,12 @@ impl GamePacketHandler<'_> {
                 // set the partial world to an empty world (when we add chunks or entities,
                 // those will be in the `worlds`)
 
-                *world_holder.partial.write() = PartialWorld::new(
+                world_holder.partial = Arc::new(PartialWorld::new(
                     azalea_world::chunk::calculate_chunk_storage_range(
                         client_information.view_distance.into(),
                     ),
                     Some(self.player),
-                );
+                ));
                 world_holder.shared = weak_world;
 
                 // every entity is now unloaded by this player
@@ -1509,7 +1508,7 @@ impl GamePacketHandler<'_> {
 
                 if !should_apply_entity_update(
                     &mut commands,
-                    &mut world_holder.partial.write(),
+                    &world_holder.partial,
                     entity,
                     entity_update_query,
                 ) {
@@ -1687,7 +1686,7 @@ fn move_entity(
 
     if !should_apply_entity_update(
         &mut commands,
-        &mut world_holder.partial.write(),
+        &world_holder.partial,
         entity,
         entity_update_query,
     ) {

--- a/azalea-client/src/plugins/packet/relative_updates.rs
+++ b/azalea-client/src/plugins/packet/relative_updates.rs
@@ -22,7 +22,6 @@ use azalea_entity::LocalEntity;
 use azalea_world::PartialWorld;
 use bevy_ecs::prelude::*;
 use derive_more::{Deref, DerefMut};
-use parking_lot::RwLock;
 use tracing::{debug, warn};
 
 use crate::packet::as_system;
@@ -39,13 +38,13 @@ use crate::packet::as_system;
 /// other clients within render distance will get too. You usually don't need
 /// this when the change isn't relative either.
 pub struct RelativeEntityUpdate {
-    pub partial_world: Arc<RwLock<PartialWorld>>,
+    pub partial_world: Arc<PartialWorld>,
     // a function that takes the entity and updates it
     pub update: Box<dyn FnOnce(&mut EntityWorldMut) + Send + Sync>,
 }
 impl RelativeEntityUpdate {
     pub fn new(
-        partial_world: Arc<RwLock<PartialWorld>>,
+        partial_world: Arc<PartialWorld>,
         update: impl FnOnce(&mut EntityWorldMut) + Send + Sync + 'static,
     ) -> Self {
         Self {
@@ -81,11 +80,11 @@ pub type EntityUpdateQuery<'world, 'state, 'a> = Query<
 /// it's more performant than the Command.
 pub fn should_apply_entity_update(
     commands: &mut Commands,
-    partial_world: &mut PartialWorld,
+    partial_world: &PartialWorld,
     entity: Entity,
     entity_update_query: EntityUpdateQuery,
 ) -> bool {
-    let partial_entity_infos = &mut partial_world.entity_infos;
+    let mut partial_entity_infos = partial_world.entity_infos.write();
 
     if Some(entity) == partial_entity_infos.owner_entity {
         // if the entity owns this partial world, it's always allowed to update itself
@@ -141,12 +140,8 @@ impl EntityCommand for RelativeEntityUpdate {
 
         entity_mut.world_scope(|ecs| {
             as_system::<(Commands, EntityUpdateQuery)>(ecs, |(mut commands, query)| {
-                should_update = should_apply_entity_update(
-                    &mut commands,
-                    &mut partial_world.write(),
-                    entity,
-                    query,
-                );
+                should_update =
+                    should_apply_entity_update(&mut commands, &partial_world, entity, query);
             });
         });
 

--- a/azalea-entity/src/plugin/mod.rs
+++ b/azalea-entity/src/plugin/mod.rs
@@ -347,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_is_trapdoor_useable_as_ladder() {
-        let mut partial_world = PartialWorld::default();
+        let partial_world = PartialWorld::default();
         let mut chunks = ChunkStorage::default();
         partial_world.chunks.set(
             &ChunkPos { x: 0, z: 0 },

--- a/azalea-physics/tests/physics.rs
+++ b/azalea-physics/tests/physics.rs
@@ -39,7 +39,8 @@ pub fn insert_overworld(app: &mut App) -> Arc<RwLock<World>> {
 fn test_gravity() {
     let mut app = make_test_app();
     let world_lock = insert_overworld(&mut app);
-    let mut partial_world = PartialWorld::default();
+    let partial_world = PartialWorld::default();
+
     // the entity has to be in a loaded chunk for physics to work
     partial_world.chunks.set(
         &ChunkPos { x: 0, z: 0 },
@@ -96,7 +97,7 @@ fn test_gravity() {
 fn test_collision() {
     let mut app = make_test_app();
     let world_lock = insert_overworld(&mut app);
-    let mut partial_world = PartialWorld::default();
+    let partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: 0, z: 0 },
@@ -153,7 +154,7 @@ fn test_collision() {
 fn test_slab_collision() {
     let mut app = make_test_app();
     let world_lock = insert_overworld(&mut app);
-    let mut partial_world = PartialWorld::default();
+    let partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: 0, z: 0 },
@@ -204,7 +205,7 @@ fn test_slab_collision() {
 fn test_top_slab_collision() {
     let mut app = make_test_app();
     let world_lock = insert_overworld(&mut app);
-    let mut partial_world = PartialWorld::default();
+    let partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: 0, z: 0 },
@@ -259,7 +260,7 @@ fn test_weird_wall_collision() {
         -64,
         &RegistryHolder::default(),
     );
-    let mut partial_world = PartialWorld::default();
+    let partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: 0, z: 0 },
@@ -319,7 +320,7 @@ fn test_negative_coordinates_weird_wall_collision() {
         -64,
         &RegistryHolder::default(),
     );
-    let mut partial_world = PartialWorld::default();
+    let partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: -1, z: -1 },
@@ -383,7 +384,7 @@ fn spawn_and_unload_world() {
         -64,
         &RegistryHolder::default(),
     );
-    let mut partial_world = PartialWorld::default();
+    let partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: -1, z: -1 },
@@ -426,7 +427,7 @@ fn spawn_and_unload_world() {
 fn test_afk_pool() {
     let mut app = make_test_app();
     let world_lock = insert_overworld(&mut app);
-    let mut partial_world = PartialWorld::default();
+    let partial_world = PartialWorld::default();
 
     partial_world.chunks.set(
         &ChunkPos { x: 0, z: 0 },

--- a/azalea-world/Cargo.toml
+++ b/azalea-world/Cargo.toml
@@ -11,6 +11,7 @@ criterion.workspace = true
 rand.workspace = true
 
 [dependencies]
+arc-swap.workspace = true
 azalea-block.workspace = true
 azalea-buf.workspace = true
 azalea-core = { workspace = true, features = ["serde", "bevy_ecs"] }

--- a/azalea-world/src/chunk/partial.rs
+++ b/azalea-world/src/chunk/partial.rs
@@ -1,9 +1,13 @@
 use std::{
     fmt::{self, Debug},
     io::Cursor,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicI32, Ordering},
+    },
 };
 
+use arc_swap::ArcSwapOption;
 use azalea_block::BlockState;
 use azalea_buf::BufReadError;
 use azalea_core::{
@@ -21,21 +25,29 @@ use crate::{Chunk, chunk::storage::ChunkStorage};
 /// This has support for using a shared [`ChunkStorage`].
 pub struct PartialChunkStorage {
     /// The center of the view, i.e. the chunk the player is currently in.
-    view_center: ChunkPos,
-    pub(crate) chunk_radius: u32,
+    view_center_x: AtomicI32,
+    view_center_z: AtomicI32,
     view_range: u32,
+
+    pub(crate) chunk_radius: u32,
     // chunks is a list of size chunk_radius * chunk_radius
-    chunks: Box<[Option<Arc<RwLock<Chunk>>>]>,
+    chunks: Box<[ArcSwapOption<RwLock<Chunk>>]>,
 }
 
 impl PartialChunkStorage {
     pub fn new(chunk_radius: u32) -> Self {
         let view_range = chunk_radius * 2 + 1;
+
+        let storage_size = (view_range * view_range) as usize;
+        let mut chunks = Vec::with_capacity(storage_size);
+        chunks.resize_with(storage_size, ArcSwapOption::const_empty);
+
         PartialChunkStorage {
-            view_center: ChunkPos::new(0, 0),
             chunk_radius,
             view_range,
-            chunks: vec![None; (view_range * view_range) as usize].into(),
+            view_center_x: AtomicI32::new(0),
+            view_center_z: AtomicI32::new(0),
+            chunks: chunks.into_boxed_slice(),
         }
     }
 
@@ -43,7 +55,7 @@ impl PartialChunkStorage {
     ///
     /// This should be called when the client receives a `SetChunkCacheCenter`
     /// packet.
-    pub fn update_view_center(&mut self, view_center: ChunkPos) {
+    pub fn update_view_center(&self, view_center: ChunkPos) {
         // this code block makes it force unload the chunks that are out of range after
         // updating the view center. it's usually fine without it but the commented code
         // is there in case you want to temporarily uncomment to test something
@@ -57,13 +69,16 @@ impl PartialChunkStorage {
         // }
         // ```
 
-        self.view_center = view_center;
+        self.view_center_x.store(view_center.x, Ordering::Relaxed);
+        self.view_center_z.store(view_center.z, Ordering::Relaxed);
     }
 
     /// Get the center of the view. This is usually the chunk that the player is
     /// in.
     pub fn view_center(&self) -> ChunkPos {
-        self.view_center
+        let x = self.view_center_x.load(Ordering::Relaxed);
+        let z = self.view_center_z.load(Ordering::Relaxed);
+        ChunkPos::new(x, z)
     }
 
     pub fn view_range(&self) -> u32 {
@@ -82,8 +97,9 @@ impl PartialChunkStorage {
         let view_range = self.view_range as i32;
 
         // find the base from the view center
-        let base_x = self.view_center.x.div_euclid(view_range) * view_range;
-        let base_z = self.view_center.z.div_euclid(view_range) * view_range;
+        let base = self.view_center();
+        let base_x = base.x.div_euclid(view_range) * view_range;
+        let base_z = base.z.div_euclid(view_range) * view_range;
 
         // add the offset from the base
         let offset_x = index as i32 / view_range;
@@ -93,7 +109,7 @@ impl PartialChunkStorage {
     }
 
     pub fn in_range(&self, chunk_pos: &ChunkPos) -> bool {
-        in_range_for_view_center_and_radius(chunk_pos, self.view_center, self.chunk_radius)
+        in_range_for_view_center_and_radius(chunk_pos, self.view_center(), self.chunk_radius)
     }
 
     pub fn set_block_state(
@@ -114,7 +130,7 @@ impl PartialChunkStorage {
     }
 
     pub fn replace_with_packet_data(
-        &mut self,
+        &self,
         pos: &ChunkPos,
         data: &mut Cursor<&[u8]>,
         heightmaps: &[(HeightmapKind, Box<[u64]>)],
@@ -143,32 +159,24 @@ impl PartialChunkStorage {
     /// Use [`ChunkStorageTrait::get`] to get a chunk from the shared storage.
     ///
     /// [`ChunkStorageTrait::get`]: crate::chunk::storage::ChunkStorageTrait::get
-    pub fn limited_get(&self, pos: &ChunkPos) -> Option<&Arc<RwLock<Chunk>>> {
+    pub fn limited_get(&self, pos: &ChunkPos) -> Option<Arc<RwLock<Chunk>>> {
         if !self.in_range(pos) {
             warn!(
                 "Chunk at {:?} is not in the render distance (center: {:?}, {} chunks)",
-                pos, self.view_center, self.chunk_radius,
+                pos,
+                self.view_center(),
+                self.chunk_radius,
             );
             return None;
         }
 
-        let index = self.index_from_chunk_pos(pos);
-        self.chunks[index].as_ref()
-    }
-    /// Get a mutable reference to a [`Chunk`] within render distance, or
-    /// `None` if it's not loaded.
-    ///
-    /// Use [`ChunkStorageTrait::get`] to get a chunk from the shared storage.
-    ///
-    /// [`ChunkStorageTrait::get`]: crate::chunk::storage::ChunkStorageTrait::get
-    pub fn limited_get_mut(&mut self, pos: &ChunkPos) -> Option<&mut Option<Arc<RwLock<Chunk>>>> {
-        if !self.in_range(pos) {
-            return None;
+        let guard = self.chunks.get(self.index_from_chunk_pos(pos))?;
+
+        if guard.load().is_some() {
+            guard.load_full()
+        } else {
+            None
         }
-
-        let index = self.index_from_chunk_pos(pos);
-
-        Some(&mut self.chunks[index])
     }
 
     /// Set a chunk in the shared storage and reference it from the limited
@@ -178,7 +186,7 @@ impl PartialChunkStorage {
     ///
     /// # Panics
     /// If the chunk is not in the render distance.
-    pub fn set(&mut self, pos: &ChunkPos, chunk: Option<Chunk>, chunk_storage: &mut ChunkStorage) {
+    pub fn set(&self, pos: &ChunkPos, chunk: Option<Chunk>, chunk_storage: &mut ChunkStorage) {
         let new_chunk = chunk.map(|c| chunk_storage.upsert(*pos, c));
         self.limited_set(pos, new_chunk);
     }
@@ -191,22 +199,28 @@ impl PartialChunkStorage {
     ///
     /// # Panics
     /// If the chunk is not in the render distance.
-    pub fn limited_set(&mut self, pos: &ChunkPos, chunk: Option<Arc<RwLock<Chunk>>>) {
-        if let Some(chunk_mut) = self.limited_get_mut(pos) {
-            *chunk_mut = chunk;
+    pub fn limited_set(&self, pos: &ChunkPos, chunk: Option<Arc<RwLock<Chunk>>>) {
+        if let Some(guard) = self.chunks.get(self.index_from_chunk_pos(pos)) {
+            guard.store(chunk);
         }
     }
 
     /// Get an iterator over all the chunks in the storage.
-    pub fn chunks(&self) -> impl Iterator<Item = &Option<Arc<RwLock<Chunk>>>> {
+    pub fn chunks(&self) -> impl Iterator<Item = &ArcSwapOption<RwLock<Chunk>>> {
         self.chunks.iter()
+    }
+
+    /// Clears the internal references to chunks and resets the view center.
+    pub fn reset(&self) {
+        self.update_view_center(ChunkPos::new(0, 0));
+        self.chunks.iter().for_each(|chunk| chunk.store(None));
     }
 }
 
 impl Debug for PartialChunkStorage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PartialChunkStorage")
-            .field("view_center", &self.view_center)
+            .field("view_center", &self.view_center())
             .field("chunk_radius", &self.chunk_radius)
             .field("view_range", &self.view_range)
             // .field("chunks", &self.chunks)
@@ -238,7 +252,7 @@ mod tests {
 
     #[test]
     fn test_chunk_pos_from_index() {
-        let mut partial_chunk_storage = PartialChunkStorage::new(5);
+        let partial_chunk_storage = PartialChunkStorage::new(5);
         partial_chunk_storage.update_view_center(ChunkPos::new(0, -1));
         assert_eq!(
             partial_chunk_storage.chunk_pos_from_index(

--- a/azalea-world/src/chunk/storage.rs
+++ b/azalea-world/src/chunk/storage.rs
@@ -207,12 +207,14 @@ mod tests {
     #[test]
     fn test_out_of_bounds_y() {
         let mut chunk_storage = ChunkStorage::default();
-        let mut partial_chunk_storage = PartialChunkStorage::default();
+        let partial_chunk_storage = PartialChunkStorage::default();
+
         partial_chunk_storage.set(
             &ChunkPos { x: 0, z: 0 },
             Some(Chunk::default()),
             &mut chunk_storage,
         );
+
         assert!(
             chunk_storage
                 .get_block_state(BlockPos { x: 0, y: 319, z: 0 })

--- a/azalea-world/src/find_blocks.rs
+++ b/azalea-world/src/find_blocks.rs
@@ -259,7 +259,7 @@ mod tests {
         let mut world = World::default();
 
         let chunk_storage = &mut world.chunks;
-        let mut partial_chunk_storage = PartialChunkStorage::default();
+        let partial_chunk_storage = PartialChunkStorage::default();
 
         // block at (17, 0, 0) and (0, 18, 0)
 
@@ -286,7 +286,7 @@ mod tests {
         let mut world = World::default();
 
         let chunk_storage = &mut world.chunks;
-        let mut partial_chunk_storage = PartialChunkStorage::default();
+        let partial_chunk_storage = PartialChunkStorage::default();
 
         // block at (-1, 0, 0) and (15, 0, 0)
 

--- a/azalea-world/src/world.rs
+++ b/azalea-world/src/world.rs
@@ -11,6 +11,7 @@ use azalea_core::{
 use azalea_registry::data::Biome;
 use bevy_ecs::entity::Entity;
 use nohash_hasher::IntMap;
+use parking_lot::RwLock;
 
 use crate::{ChunkStorage, PartialChunkStorage};
 
@@ -26,21 +27,21 @@ pub struct PartialWorld {
     pub chunks: PartialChunkStorage,
     /// Some metadata about entities, like what entities are in certain chunks.
     /// This does not contain the entity data itself, that's in the ECS.
-    pub entity_infos: PartialEntityInfos,
+    pub entity_infos: RwLock<PartialEntityInfos>,
 }
 
 impl PartialWorld {
     pub fn new(chunk_radius: u32, owner_entity: Option<Entity>) -> Self {
         PartialWorld {
             chunks: PartialChunkStorage::new(chunk_radius),
-            entity_infos: PartialEntityInfos::new(owner_entity),
+            entity_infos: RwLock::new(PartialEntityInfos::new(owner_entity)),
         }
     }
 
     /// Clears the internal references to chunks in the [`PartialWorld`] and
     /// resets the view center.
-    pub fn reset(&mut self) {
-        self.chunks = PartialChunkStorage::new(self.chunks.chunk_radius);
+    pub fn reset(&self) {
+        self.chunks.reset();
     }
 }
 
@@ -156,7 +157,7 @@ impl Default for PartialWorld {
         let entity_storage = PartialEntityInfos::default();
         Self {
             chunks: chunk_storage,
-            entity_infos: entity_storage,
+            entity_infos: RwLock::new(entity_storage),
         }
     }
 }

--- a/azalea/src/client_impl/mod.rs
+++ b/azalea/src/client_impl/mod.rs
@@ -357,12 +357,12 @@ impl Client {
     /// # use azalea_core::position::ChunkPos;
     /// # fn example(client: &azalea::Client) -> azalea::error::AzaleaResult<()> {
     /// let world = client.partial_world()?;
-    /// let is_0_0_loaded = world.read().chunks.limited_get(&ChunkPos::new(0, 0)).is_some();
+    /// let is_0_0_loaded = world.chunks.limited_get(&ChunkPos::new(0, 0)).is_some();
     /// # Ok(())
     /// # }
-    pub fn partial_world(&self) -> AzaleaResult<Arc<RwLock<PartialWorld>>> {
-        let world_holder = self.component::<WorldHolder>()?;
-        Ok(world_holder.partial.clone())
+    pub fn partial_world(&self) -> AzaleaResult<Arc<PartialWorld>> {
+        self.component::<WorldHolder>()
+            .map(|holder| holder.partial.clone())
     }
 
     /// Returns whether we have a received the login packet yet.

--- a/azalea/src/pathfinder/simulation.rs
+++ b/azalea/src/pathfinder/simulation.rs
@@ -106,7 +106,7 @@ fn create_simulation_player_complete_bundle(
         ),
         azalea_client::local_player::WorldHolder {
             // the partial world is never actually used by the pathfinder, so we can leave it empty
-            partial: Arc::new(RwLock::new(PartialWorld::default())),
+            partial: Arc::new(PartialWorld::default()),
             shared: world.clone(),
         },
         Inventory::default(),

--- a/azalea/src/pathfinder/world.rs
+++ b/azalea/src/pathfinder/world.rs
@@ -727,7 +727,7 @@ mod tests {
 
     #[test]
     fn test_is_passable() {
-        let mut partial_world = PartialWorld::default();
+        let partial_world = PartialWorld::default();
         let mut world = ChunkStorage::default();
 
         partial_world
@@ -749,8 +749,9 @@ mod tests {
 
     #[test]
     fn test_is_solid() {
-        let mut partial_world = PartialWorld::default();
+        let partial_world = PartialWorld::default();
         let mut world = ChunkStorage::default();
+
         partial_world
             .chunks
             .set(&ChunkPos { x: 0, z: 0 }, Some(Chunk::default()), &mut world);
@@ -770,7 +771,7 @@ mod tests {
 
     #[test]
     fn test_is_standable() {
-        let mut partial_world = PartialWorld::default();
+        let partial_world = PartialWorld::default();
         let mut world = ChunkStorage::default();
         partial_world
             .chunks


### PR DESCRIPTION
Removes a `.read()`/`.write()` and some potential deadlocks.