### PR TITLE
docs: Fix readme link size for accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ _Currently supported Minecraft version: `26.2`._
 
 ## Non-goals
 
-- Supporting multiple versions of Minecraft at the same time[\*](https://github.com/azalea-rs/azalea-viaversion).
-- Graphics[\*](https://github.com/urisinger/azalea-graphics).
+- Supporting multiple versions of Minecraft at the same time [[Note]](https://github.com/azalea-rs/azalea-viaversion).
+- Graphics [[Note]](https://github.com/urisinger/azalea-graphics).
 - Bedrock edition.
 
 ## Documentation


### PR DESCRIPTION
I was just trying to read this on mobile and had a hard time clicking the tiny asterisks. I'd appreciate it if you keep all links longer than a couple characters!

Change it to whatever you want though, no need to merge this in particular if you'd rather something else. Thanks for the great project!