### PR TITLE
feat: Main supporting blockpos

### DIFF
--- a/azalea-client/src/plugins/packet/game/mod.rs
+++ b/azalea-client/src/plugins/packet/game/mod.rs
@@ -16,7 +16,7 @@ use azalea_entity::{
     inventory::Inventory,
     metadata::{Health, apply_metadata},
 };
-use azalea_physics::collision::calculate_supporting_block;
+use azalea_physics::collision::calculate_supporting_block_at_current_pos;
 use azalea_protocol::{
     common::movements::MoveFlags,
     packets::{
@@ -1531,7 +1531,7 @@ impl GamePacketHandler<'_> {
                     return;
                 }
 
-                let block = calculate_supporting_block(
+                let block = calculate_supporting_block_at_current_pos(
                     new_on_ground,
                     None,
                     **position,
@@ -1722,7 +1722,7 @@ fn move_entity(
         }
     }
 
-    let block = calculate_supporting_block(
+    let block = calculate_supporting_block_at_current_pos(
             p.on_ground,
             None,
             **position,

--- a/azalea-client/src/plugins/packet/game/mod.rs
+++ b/azalea-client/src/plugins/packet/game/mod.rs
@@ -11,6 +11,7 @@ use azalea_core::{
 use azalea_entity::{
     Dead, EntityBundle, EntityKindComponent, HasClientLoaded, LoadedBy, LocalEntity, LookDirection,
     Physics, PlayerAbilities, Position,
+    dimensions::EntityDimensions,
     effect_events::{AddEffectEvent, RemoveEffectsEvent},
     indexing::{EntityIdIndex, EntityUuidIndex},
     inventory::Inventory,
@@ -1491,6 +1492,7 @@ impl GamePacketHandler<'_> {
                 &mut Physics,
                 &mut Position,
                 &mut LookDirection,
+                &EntityDimensions,
                 Option<&LocalEntity>,
             )>,
             EntityUpdateQuery,
@@ -1517,7 +1519,7 @@ impl GamePacketHandler<'_> {
                     return;
                 }
 
-                let Ok((mut physics, mut position, mut look_direction, local_entity)) =
+                let Ok((mut physics, mut position, mut look_direction, dimensions, local_entity)) =
                     entity_query.get_mut(entity)
                 else {
                     return;
@@ -1529,6 +1531,16 @@ impl GamePacketHandler<'_> {
                 if is_client_authoritative {
                     debug!("Ignoring entity position sync packet for local player");
                     return;
+                }
+
+                if **position != new_position {
+                    **position = new_position;
+
+                    physics.bounding_box = dimensions.make_bounding_box(**position);
+                }
+
+                if *look_direction != new_look_direction {
+                    *look_direction = new_look_direction;
                 }
 
                 let block = calculate_supporting_block_at_current_pos(
@@ -1543,14 +1555,6 @@ impl GamePacketHandler<'_> {
                     entity,
                 );
                 physics.set_on_ground(new_on_ground, block);
-
-                if **position != new_position {
-                    **position = new_position;
-                }
-
-                if *look_direction != new_look_direction {
-                    *look_direction = new_look_direction;
-                }
             },
         );
     }
@@ -1712,6 +1716,8 @@ fn move_entity(
 
         if new_position != **position {
             **position = new_position;
+            
+            physics.bounding_box = physics.bounding_box.move_relative(new_delta.into())
         }
     }
 
@@ -1723,16 +1729,13 @@ fn move_entity(
     }
 
     let block = calculate_supporting_block_at_current_pos(
-            p.on_ground,
-            None,
-            **position,
-            &physics,
-            &world_holder.shared.read(),
-            entity,
-        );
-
-    physics.set_on_ground(
         p.on_ground,
-        block,
+        None,
+        **position,
+        &physics,
+        &world_holder.shared.read(),
+        entity,
     );
+
+    physics.set_on_ground(p.on_ground, block);
 }

--- a/azalea-client/src/plugins/packet/game/mod.rs
+++ b/azalea-client/src/plugins/packet/game/mod.rs
@@ -1715,9 +1715,8 @@ fn move_entity(
         physics.vec_delta_codec.set_base(new_position);
 
         if new_position != **position {
+            physics.bounding_box = physics.bounding_box.move_relative(new_position - **position);
             **position = new_position;
-            
-            physics.bounding_box = physics.bounding_box.move_relative(new_delta.into())
         }
     }
 

--- a/azalea-client/src/plugins/packet/game/mod.rs
+++ b/azalea-client/src/plugins/packet/game/mod.rs
@@ -16,6 +16,7 @@ use azalea_entity::{
     inventory::Inventory,
     metadata::{Health, apply_metadata},
 };
+use azalea_physics::collision::calculate_supporting_block;
 use azalea_protocol::{
     common::movements::MoveFlags,
     packets::{
@@ -1530,7 +1531,18 @@ impl GamePacketHandler<'_> {
                     return;
                 }
 
-                physics.set_on_ground(new_on_ground);
+                let block = calculate_supporting_block(
+                    new_on_ground,
+                    None,
+                    **position,
+                    &*physics,
+                    &*world_holder.shared.read(), /* should it really be `shared` though? should
+                                                   * we change all the type in the chain to
+                                                   * partial world? typewise, this compiles, but
+                                                   * logically doesn't make sense */
+                    entity,
+                );
+                physics.set_on_ground(new_on_ground, block);
 
                 if **position != new_position {
                     **position = new_position;
@@ -1710,5 +1722,17 @@ fn move_entity(
         }
     }
 
-    physics.set_on_ground(p.on_ground);
+    let block = calculate_supporting_block(
+            p.on_ground,
+            None,
+            **position,
+            &physics,
+            &world_holder.shared.read(),
+            entity,
+        );
+
+    physics.set_on_ground(
+        p.on_ground,
+        block,
+    );
 }

--- a/azalea-entity/src/lib.rs
+++ b/azalea-entity/src/lib.rs
@@ -283,6 +283,8 @@ pub struct Physics {
 
     on_ground: bool,
     last_on_ground: bool,
+    // Client side support blockpos is update together with on_ground, so it's put here
+    main_supporting_blockpos: Option<BlockPos>,
 
     /// The number of ticks until we jump again, if the jump key is being held.
     ///
@@ -325,6 +327,7 @@ impl Physics {
 
             on_ground: false,
             last_on_ground: false,
+            main_supporting_blockpos: None,
 
             no_jump_delay: 0,
 
@@ -348,10 +351,16 @@ impl Physics {
     pub fn on_ground(&self) -> bool {
         self.on_ground
     }
-    /// Updates [`Self::on_ground`] and [`Self::last_on_ground`].
-    pub fn set_on_ground(&mut self, on_ground: bool) {
+    /// Updates [`Self::on_ground`], [`Self::last_on_ground`] and
+    /// [`Self::main_supporting_blockpos`]. roughly
+    /// `Entity.setOnGround`/`Entity.setOnGroundWithMovement` in vanilla
+    /// Forcing the supporting_block to be updated together with on_gound just
+    /// like vanilla should make it harder to accidentally updated on_ground but
+    /// not supporting block
+    pub fn set_on_ground(&mut self, on_ground: bool, supporting_block: Option<BlockPos>) {
         self.last_on_ground = self.on_ground;
         self.on_ground = on_ground;
+        self.main_supporting_blockpos = supporting_block;
     }
 
     /// The last value of the on_ground value.
@@ -382,6 +391,10 @@ impl Physics {
 
     pub fn set_old_pos(&mut self, pos: Position) {
         self.old_position = *pos;
+    }
+
+    pub fn main_supporting_pos(&self) -> Option<BlockPos> {
+        self.main_supporting_blockpos
     }
 }
 

--- a/azalea-entity/src/lib.rs
+++ b/azalea-entity/src/lib.rs
@@ -260,11 +260,6 @@ pub struct SupportingBlockCtx {
     pub on_ground_no_supporting_block: bool,
 }
 
-impl SupportingBlockCtx {
-    pub fn new() -> SupportingBlockCtx {
-        Self { main_supporting_blockpos: None, on_ground_no_supporting_block: false }
-    }
-}
 
 /// The physics data relating to the entity, such as position, velocity, and
 /// bounding box.
@@ -339,7 +334,7 @@ impl Physics {
 
             on_ground: false,
             last_on_ground: false,
-            supporting_ctx: SupportingBlockCtx::new(),
+            supporting_ctx: SupportingBlockCtx::default(),
 
             no_jump_delay: 0,
 

--- a/azalea-entity/src/lib.rs
+++ b/azalea-entity/src/lib.rs
@@ -257,12 +257,12 @@ impl Eq for LookDirection {}
 #[derive(Clone, Debug, Default)]
 pub struct SupportingBlockCtx {
     pub main_supporting_blockpos: Option<BlockPos>,
-    pub on_ground_no_supporing_block: bool,
+    pub on_ground_no_supporting_block: bool,
 }
 
 impl SupportingBlockCtx {
     pub fn new() -> SupportingBlockCtx {
-        Self { main_supporting_blockpos: None, on_ground_no_supporing_block: false }
+        Self { main_supporting_blockpos: None, on_ground_no_supporting_block: false }
     }
 }
 

--- a/azalea-entity/src/lib.rs
+++ b/azalea-entity/src/lib.rs
@@ -254,6 +254,18 @@ impl Hash for LookDirection {
 }
 impl Eq for LookDirection {}
 
+#[derive(Clone, Debug, Default)]
+pub struct SupportingBlockCtx {
+    pub main_supporting_blockpos: Option<BlockPos>,
+    pub on_ground_no_supporing_block: bool,
+}
+
+impl SupportingBlockCtx {
+    pub fn new() -> SupportingBlockCtx {
+        Self { main_supporting_blockpos: None, on_ground_no_supporing_block: false }
+    }
+}
+
 /// The physics data relating to the entity, such as position, velocity, and
 /// bounding box.
 #[cfg_attr(feature = "bevy_ecs", derive(bevy_ecs::component::Component))]
@@ -284,7 +296,7 @@ pub struct Physics {
     on_ground: bool,
     last_on_ground: bool,
     // Client side support blockpos is update together with on_ground, so it's put here
-    main_supporting_blockpos: Option<BlockPos>,
+    supporting_ctx: SupportingBlockCtx,
 
     /// The number of ticks until we jump again, if the jump key is being held.
     ///
@@ -327,7 +339,7 @@ impl Physics {
 
             on_ground: false,
             last_on_ground: false,
-            main_supporting_blockpos: None,
+            supporting_ctx: SupportingBlockCtx::new(),
 
             no_jump_delay: 0,
 
@@ -357,10 +369,10 @@ impl Physics {
     /// Forcing the supporting_block to be updated together with on_gound just
     /// like vanilla should make it harder to accidentally updated on_ground but
     /// not supporting block
-    pub fn set_on_ground(&mut self, on_ground: bool, supporting_block: Option<BlockPos>) {
+    pub fn set_on_ground(&mut self, on_ground: bool, supporting_ctx: SupportingBlockCtx) {
         self.last_on_ground = self.on_ground;
         self.on_ground = on_ground;
-        self.main_supporting_blockpos = supporting_block;
+        self.supporting_ctx = supporting_ctx;
     }
 
     /// The last value of the on_ground value.
@@ -393,8 +405,8 @@ impl Physics {
         self.old_position = *pos;
     }
 
-    pub fn main_supporting_pos(&self) -> Option<BlockPos> {
-        self.main_supporting_blockpos
+    pub fn supporting_ctx(&self) -> &SupportingBlockCtx {
+        &self.supporting_ctx
     }
 }
 

--- a/azalea-entity/src/plugin/mod.rs
+++ b/azalea-entity/src/plugin/mod.rs
@@ -320,7 +320,7 @@ pub fn on_pos(
     pos: Position,
     physics: &Physics,
 ) -> BlockPos {
-    if let Some(main_supporting_block) = physics.main_supporting_pos() {
+    if let Some(main_supporting_block) = physics.supporting_ctx().main_supporting_blockpos {
         if !(offset > 1e-5f32) {
             main_supporting_block
         } else {

--- a/azalea-entity/src/plugin/mod.rs
+++ b/azalea-entity/src/plugin/mod.rs
@@ -11,7 +11,13 @@ use azalea_core::{
     position::{BlockPos, ChunkPos},
     tick::GameTick,
 };
-use azalea_registry::{builtin::BlockKind, tags};
+use azalea_registry::{
+    builtin::BlockKind,
+    tags::{
+        self,
+        blocks::{FENCE_GATES, FENCES, WALLS},
+    },
+};
 use azalea_world::{ChunkStorage, WorldName, Worlds};
 use bevy_app::{App, Plugin, PostUpdate, Update};
 use bevy_ecs::prelude::*;
@@ -292,8 +298,8 @@ pub fn update_in_loaded_chunk(
 }
 
 /// Get the position of the block below the entity, but a little lower.
-pub fn on_pos_legacy(chunk_storage: &ChunkStorage, position: Position) -> BlockPos {
-    on_pos(0.2, chunk_storage, position)
+pub fn on_pos_legacy(chunk_storage: &ChunkStorage, pos: Position, physics: &Physics) -> BlockPos {
+    on_pos(0.2, chunk_storage, pos, physics)
 }
 
 // int x = Mth.floor(this.position.x);
@@ -308,29 +314,44 @@ pub fn on_pos_legacy(chunk_storage: &ChunkStorage, position: Position) -> BlockP
 //    }
 // }
 // return var5;
-pub fn on_pos(offset: f32, chunk_storage: &ChunkStorage, pos: Position) -> BlockPos {
-    let x = pos.x.floor() as i32;
-    let y = (pos.y - offset as f64).floor() as i32;
-    let z = pos.z.floor() as i32;
-    let pos = BlockPos { x, y, z };
-
-    // TODO: check if block below is a fence, wall, or fence gate
-    let block_pos = pos.down(1);
-    let block_state = chunk_storage.get_block_state(block_pos);
-    if block_state == Some(BlockState::AIR) {
-        let block_pos_below = block_pos.down(1);
-        let block_state_below = chunk_storage.get_block_state(block_pos_below);
-        if let Some(_block_state_below) = block_state_below {
-            // if block_state_below.is_fence()
-            //     || block_state_below.is_wall()
-            //     || block_state_below.is_fence_gate()
-            // {
-            //     return block_pos_below;
-            // }
+pub fn on_pos(
+    offset: f32,
+    chunk_storage: &ChunkStorage,
+    pos: Position,
+    physics: &Physics,
+) -> BlockPos {
+    if let Some(main_supporting_block) = physics.main_supporting_pos() {
+        if !(offset < 1e-5f32) {
+            main_supporting_block
+        } else {
+            let block_state_below = chunk_storage
+                .get_block_state(main_supporting_block)
+                .unwrap_or(BlockState::from(BlockKind::VoidAir));
+            let block_kind_below = block_state_below.as_block_kind();
+            if (!(offset <= 0.5) || !FENCES.contains(&block_kind_below))
+                && !WALLS.contains(&block_kind_below)
+                && !(FENCE_GATES.contains(&block_kind_below))
+            // For fence gates, vanilla uses `instanceof` to understand if it is one. The difference
+            // is that data packs can change the tags of a block so you may just some random block
+            // as a fence, where we don't seem to have this block type tag concept natively at the
+            // moment (also we don't seem to be accecpting data from data packs yet, so I think this
+            // should do the job for now)
+            {
+                main_supporting_block.with_y((pos.y - offset as f64).floor() as i32)
+            } else {
+                main_supporting_block
+            }
+        }
+    } else {
+        let x_truncated = pos.x.floor() as i32;
+        let y_truncated_below = (pos.y - offset as f64).floor() as i32;
+        let z_truncated = pos.z.floor() as i32;
+        BlockPos {
+            x: x_truncated,
+            y: y_truncated_below,
+            z: z_truncated,
         }
     }
-
-    pos
 }
 
 #[cfg(test)]

--- a/azalea-entity/src/plugin/mod.rs
+++ b/azalea-entity/src/plugin/mod.rs
@@ -321,7 +321,7 @@ pub fn on_pos(
     physics: &Physics,
 ) -> BlockPos {
     if let Some(main_supporting_block) = physics.main_supporting_pos() {
-        if !(offset < 1e-5f32) {
+        if !(offset > 1e-5f32) {
             main_supporting_block
         } else {
             let block_state_below = chunk_storage

--- a/azalea-physics/src/collision/mod.rs
+++ b/azalea-physics/src/collision/mod.rs
@@ -285,7 +285,7 @@ pub fn calculate_supporting_block(
     if !on_ground {
         return SupportingBlockCtx {
             main_supporting_blockpos: None,
-            on_ground_no_supporing_block: false,
+            on_ground_no_supporting_block: false,
         };
     }
 
@@ -303,7 +303,7 @@ pub fn calculate_supporting_block(
         EntityCollisionContext::of(Some(source_entity)),
     );
 
-    let pos = if pos.is_some() || physics.supporting_ctx().on_ground_no_supporing_block {
+    let pos = if pos.is_some() || physics.supporting_ctx().on_ground_no_supporting_block {
         pos
     } else if let Some(movement) = movement {
         let fallback_testbox = test_box.move_relative(Vec3 {
@@ -323,7 +323,7 @@ pub fn calculate_supporting_block(
 
     SupportingBlockCtx {
         main_supporting_blockpos: pos,
-        on_ground_no_supporing_block: pos.is_none(),
+        on_ground_no_supporting_block: pos.is_none(),
     }
 }
 

--- a/azalea-physics/src/collision/mod.rs
+++ b/azalea-physics/src/collision/mod.rs
@@ -204,7 +204,7 @@ pub fn move_colliding(ctx: &mut MoveCtx, mut movement: Vec3) {
     let on_ground = vertical_collision && movement.y < 0.;
     physics.set_on_ground(
         on_ground,
-        calculate_supporting_block(
+        calculate_supporting_block_at_current_pos(
             on_ground,
             Some(movement),
             ***position,
@@ -274,7 +274,7 @@ pub fn move_colliding(ctx: &mut MoveCtx, mut movement: Vec3) {
 }
 
 /// vanilla's Entity.checkSupportingBlock
-pub fn calculate_supporting_block(
+pub fn calculate_supporting_block_at_current_pos(
     on_ground: bool,
     movement: Option<Vec3>,
     position: Vec3,

--- a/azalea-physics/src/collision/mod.rs
+++ b/azalea-physics/src/collision/mod.rs
@@ -206,7 +206,7 @@ pub fn move_colliding(ctx: &mut MoveCtx, mut movement: Vec3) {
         on_ground,
         calculate_supporting_block_at_current_pos(
             on_ground,
-            Some(movement),
+            Some(collide_result),
             ***position,
             physics,
             world,

--- a/azalea-physics/src/collision/mod.rs
+++ b/azalea-physics/src/collision/mod.rs
@@ -17,7 +17,7 @@ use azalea_core::{
 };
 use azalea_entity::{
     Attributes, Jumping, LookDirection, OnClimbable, Physics, PlayerAbilities, Pose, Position,
-    metadata::Sprinting,
+    SupportingBlockCtx, metadata::Sprinting,
 };
 use azalea_registry::builtin::BlockKind;
 use azalea_world::{ChunkStorage, World};
@@ -178,6 +178,19 @@ pub fn move_colliding(ctx: &mut MoveCtx, mut movement: Vec3) {
 
         if new_pos != ***position {
             ***position = new_pos;
+
+            // Entity.setPos also refreshes bouding box, but since we don't have required
+            // dimensions in our current pass we will just use this
+            // `move_relative`` instead of `make_bounding box`, and technically
+            // dimensions/pose doesn't change in travel, so this should be fine
+            // enough. This is added because later supporting block needs to use the new
+            // boundingbox based on the new position and is exactly what vanilla is doing,
+            // And I do feel a bit uncomfortable knowning there is a dedicated
+            // `update_bounding_box` system just for updating the boundingbox, but it seems
+            // to much to break up this move_colliding and the whole call stack into small
+            // systems
+            let new_boundingbox = physics.bounding_box.move_relative(collide_result);
+            physics.bounding_box = new_boundingbox;
         }
     }
 
@@ -260,7 +273,6 @@ pub fn move_colliding(ctx: &mut MoveCtx, mut movement: Vec3) {
     // getFireImmuneTicks()); }
 }
 
-
 /// vanilla's Entity.checkSupportingBlock
 pub fn calculate_supporting_block(
     on_ground: bool,
@@ -269,9 +281,12 @@ pub fn calculate_supporting_block(
     physics: &Physics,
     world: &World,
     source_entity: Entity,
-) -> Option<BlockPos> {
+) -> SupportingBlockCtx {
     if !on_ground {
-        return None;
+        return SupportingBlockCtx {
+            main_supporting_blockpos: None,
+            on_ground_no_supporing_block: false,
+        };
     }
 
     let test_box = {
@@ -288,7 +303,7 @@ pub fn calculate_supporting_block(
         EntityCollisionContext::of(Some(source_entity)),
     );
 
-    if pos.is_some() || physics.main_supporting_pos().is_none() {
+    let pos = if pos.is_some() || physics.supporting_ctx().on_ground_no_supporing_block {
         pos
     } else if let Some(movement) = movement {
         let fallback_testbox = test_box.move_relative(Vec3 {
@@ -304,6 +319,11 @@ pub fn calculate_supporting_block(
         )
     } else {
         pos
+    };
+
+    SupportingBlockCtx {
+        main_supporting_blockpos: pos,
+        on_ground_no_supporing_block: pos.is_none(),
     }
 }
 

--- a/azalea-physics/src/collision/mod.rs
+++ b/azalea-physics/src/collision/mod.rs
@@ -270,7 +270,7 @@ pub fn calculate_supporting_block(
     world: &World,
     source_entity: Entity,
 ) -> Option<BlockPos> {
-    if on_ground {
+    if !on_ground {
         return None;
     }
 

--- a/azalea-physics/src/collision/mod.rs
+++ b/azalea-physics/src/collision/mod.rs
@@ -30,7 +30,11 @@ use tracing::warn;
 
 use self::world_collisions::get_block_collisions;
 use crate::{
-    client_movement::ClientMovementState, collision::entity_collisions::AabbQuery,
+    client_movement::ClientMovementState,
+    collision::{
+        entity_collisions::AabbQuery,
+        world_collisions::{EntityCollisionContext, find_supporting_block},
+    },
     travel::no_collision,
 };
 
@@ -185,7 +189,17 @@ pub fn move_colliding(ctx: &mut MoveCtx, mut movement: Vec3) {
     let vertical_collision = movement.y != collide_result.y;
     physics.vertical_collision = vertical_collision;
     let on_ground = vertical_collision && movement.y < 0.;
-    physics.set_on_ground(on_ground);
+    physics.set_on_ground(
+        on_ground,
+        calculate_supporting_block(
+            on_ground,
+            Some(movement),
+            ***position,
+            physics,
+            world,
+            ctx.source_entity,
+        ),
+    );
 
     // TODO: minecraft checks for a "minor" horizontal collision here
 
@@ -244,6 +258,53 @@ pub fn move_colliding(ctx: &mut MoveCtx, mut movement: Vec3) {
     // if (this.isOnFire() && (this.isInPowderSnow ||
     // this.isInWaterRainOrBubble())) {    this.setRemainingFireTicks(-this.
     // getFireImmuneTicks()); }
+}
+
+
+/// vanilla's Entity.checkSupportingBlock
+pub fn calculate_supporting_block(
+    on_ground: bool,
+    movement: Option<Vec3>,
+    position: Vec3,
+    physics: &Physics,
+    world: &World,
+    source_entity: Entity,
+) -> Option<BlockPos> {
+    if on_ground {
+        return None;
+    }
+
+    let test_box = {
+        let mut box_ = physics.bounding_box;
+        box_.max.y = box_.min.y;
+        box_.min.y = box_.min.y - 1e-6;
+        box_
+    }; // small volume under player foot
+
+    let pos = find_supporting_block(
+        world,
+        test_box,
+        position,
+        EntityCollisionContext::of(Some(source_entity)),
+    );
+
+    if pos.is_some() || physics.main_supporting_pos().is_none() {
+        pos
+    } else if let Some(movement) = movement {
+        let fallback_testbox = test_box.move_relative(Vec3 {
+            x: -movement.x,
+            y: 0.0,
+            z: -movement.z,
+        });
+        find_supporting_block(
+            world,
+            fallback_testbox,
+            position,
+            EntityCollisionContext::of(Some(source_entity)),
+        )
+    } else {
+        pos
+    }
 }
 
 fn check_fall_damage(

--- a/azalea-physics/src/collision/mod.rs
+++ b/azalea-physics/src/collision/mod.rs
@@ -203,7 +203,7 @@ pub fn move_colliding(ctx: &mut MoveCtx, mut movement: Vec3) {
 
     // TODO: minecraft checks for a "minor" horizontal collision here
 
-    let block_pos_below = azalea_entity::on_pos_legacy(&world.chunks, **position);
+    let block_pos_below = azalea_entity::on_pos_legacy(&world.chunks, **position, physics);
     let block_state_below = world.get_block_state(block_pos_below).unwrap_or_default();
 
     check_fall_damage(

--- a/azalea-physics/src/collision/world_collisions.rs
+++ b/azalea-physics/src/collision/world_collisions.rs
@@ -25,7 +25,7 @@ pub fn get_block_collisions(world: &World, aabb: &Aabb) -> Vec<VoxelShape> {
     while let Some(item) = state.cursor.next() {
         state.compute_next(
             item,
-            &mut block_collisions,
+            &mut |collision| block_collisions.push(collision.shape),
             initial_chunk_pos,
             initial_chunk.as_deref(),
         );
@@ -49,13 +49,54 @@ pub fn get_block_and_liquid_collisions(world: &World, aabb: &Aabb) -> Vec<VoxelS
     while let Some(item) = state.cursor.next() {
         state.compute_next(
             item,
-            &mut block_collisions,
+            &mut |collision| block_collisions.push(collision.shape),
             initial_chunk_pos,
             initial_chunk.as_deref(),
         );
     }
 
     block_collisions
+}
+
+pub fn find_supporting_block(
+    world: &World,
+    collison_box: Aabb,
+    source_position: Vec3,
+    collision_context: EntityCollisionContext,
+) -> Option<BlockPos> {
+    let blocks = {
+        let mut state = BlockCollisionsState::new(world, &collison_box, collision_context);
+        let mut blocks = Vec::new();
+
+        let initial_chunk_pos = ChunkPos::from(state.cursor.origin());
+        let initial_chunk = world.chunks.get(&initial_chunk_pos);
+        let initial_chunk = initial_chunk.as_deref().map(RwLock::read);
+
+        while let Some(item) = state.cursor.next() {
+            state.compute_next(
+                item,
+                &mut |collision| blocks.push(collision.pos),
+                initial_chunk_pos,
+                initial_chunk.as_deref(),
+            );
+        }
+
+        blocks
+    };
+
+    blocks.into_iter().min_by(|a, b| {
+        let a_distance = a.center().distance_squared_to(source_position);
+        let b_distance = b.center().distance_squared_to(source_position);
+
+        a_distance
+            .total_cmp(&b_distance)
+            // Vec3i.compareTo
+            // but I assume that it is not usually used elsewhere and it maybe confusing to
+            // implement Ord for Vec3i/BlockPos.
+            .then_with(|| a.y.cmp(&b.y))
+            .then_with(|| a.z.cmp(&b.z))
+            .then_with(|| a.x.cmp(&b.x))
+    })
 }
 
 pub struct BlockCollisionsState<'a> {
@@ -70,14 +111,21 @@ pub struct BlockCollisionsState<'a> {
     cached_block_shapes: Vec<(BlockState, &'static VoxelShape)>,
 }
 
+pub struct BlockCollision {
+    pub pos: BlockPos,
+    pub shape: VoxelShape,
+}
+
 impl<'a> BlockCollisionsState<'a> {
-    fn compute_next(
+    fn compute_next<F>(
         &mut self,
         item: CursorIteration,
-        block_collisions: &mut Vec<VoxelShape>,
+        receiver: &mut F,
         initial_chunk_pos: ChunkPos,
         initial_chunk: Option<&Chunk>,
-    ) {
+    ) where
+        F: FnMut(BlockCollision),
+    {
         if item.iteration_type == CursorIterationType::Corner {
             return;
         }
@@ -109,7 +157,10 @@ impl<'a> BlockCollisionsState<'a> {
                 return;
             }
 
-            block_collisions.push(BLOCK_SHAPE.move_relative(item.pos.to_vec3_floored()));
+            receiver(BlockCollision {
+                pos: item.pos,
+                shape: BLOCK_SHAPE.move_relative(item.pos.to_vec3_floored()),
+            });
             return;
         }
 
@@ -121,7 +172,10 @@ impl<'a> BlockCollisionsState<'a> {
             return;
         }
 
-        block_collisions.push(block_shape);
+        receiver(BlockCollision {
+            pos: item.pos,
+            shape: block_shape,
+        });
     }
 
     pub fn new(world: &'a World, aabb: &'a Aabb, context: EntityCollisionContext) -> Self {

--- a/azalea-physics/src/lib.rs
+++ b/azalea-physics/src/lib.rs
@@ -18,10 +18,10 @@ use azalea_core::{
 use azalea_entity::{
     ActiveEffects, Attributes, EntityKindComponent, HasClientLoaded, Jumping, LocalEntity,
     LookDirection, OnClimbable, Physics, Pose, Position, dimensions::EntityDimensions,
-    metadata::Sprinting, move_relative,
+    metadata::Sprinting, move_relative, on_pos,
 };
 use azalea_registry::builtin::{BlockKind, EntityKind, MobEffect};
-use azalea_world::{World, WorldName, Worlds};
+use azalea_world::{ChunkStorage, World, WorldName, Worlds};
 use bevy_app::{App, Plugin, Update};
 use bevy_ecs::prelude::*;
 use clip::box_traverse_blocks;
@@ -361,7 +361,7 @@ pub fn jump_from_ground(
         .expect("All entities should be in a valid world");
     let world = world_lock.read();
 
-    let base_jump = jump_power(&world, position);
+    let base_jump = jump_power(&world, position, physics);
     let jump_power = base_jump + jump_boost_power(active_effects);
     if jump_power <= 1.0E-5 {
         return;
@@ -392,13 +392,12 @@ pub fn update_old_position(mut query: Query<(&mut Physics, &Position)>) {
     }
 }
 
-pub fn get_block_pos_below_that_affects_movement(position: Position) -> BlockPos {
-    BlockPos::new(
-        position.x.floor() as i32,
-        // TODO: this uses bounding_box.min_y instead of position.y
-        (position.y - 0.5f64).floor() as i32,
-        position.z.floor() as i32,
-    )
+pub fn get_block_pos_below_that_affects_movement(
+    chunk_storage: &ChunkStorage,
+    position: Position,
+    physics: &Physics,
+) -> BlockPos {
+    on_pos(0.500001f32, chunk_storage, position, physics)
 }
 
 fn handle_relative_friction_and_calculate_movement(ctx: &mut MoveCtx, block_friction: f32) -> Vec3 {
@@ -501,11 +500,11 @@ fn get_friction_influenced_speed(
 
 /// Returns the what the entity's jump should be multiplied by based on the
 /// block they're standing on.
-fn block_jump_factor(world: &World, position: Position) -> f32 {
+fn block_jump_factor(world: &World, position: Position, physics: &Physics) -> f32 {
     let block_at_pos = world.chunks.get_block_state(position.into());
     let block_below = world
         .chunks
-        .get_block_state(get_block_pos_below_that_affects_movement(position));
+        .get_block_state(get_block_pos_below_that_affects_movement(&world.chunks, position, physics));
 
     let block_at_pos_jump_factor = if let Some(block) = block_at_pos {
         block.behavior().jump_factor
@@ -529,8 +528,8 @@ fn block_jump_factor(world: &World, position: Position) -> f32 {
 // public double getJumpBoostPower() {
 //     return this.hasEffect(MobEffects.JUMP) ? (double)(0.1F *
 // (float)(this.getEffect(MobEffects.JUMP).getAmplifier() + 1)) : 0.0D; }
-fn jump_power(world: &World, position: Position) -> f32 {
-    0.42 * block_jump_factor(world, position)
+fn jump_power(world: &World, position: Position, physics: &Physics) -> f32 {
+    0.42 * block_jump_factor(world, position, physics)
 }
 
 fn jump_boost_power(active_effects: &ActiveEffects) -> f32 {

--- a/azalea-physics/src/travel.rs
+++ b/azalea-physics/src/travel.rs
@@ -110,7 +110,8 @@ pub fn travel(
 fn travel_in_air(ctx: &mut MoveCtx) {
     let gravity = get_effective_gravity();
 
-    let block_pos_below = get_block_pos_below_that_affects_movement(*ctx.position);
+    let block_pos_below =
+        get_block_pos_below_that_affects_movement(&ctx.world.chunks, *ctx.position, ctx.physics);
 
     let block_below = ctx
         .world

--- a/azalea/src/auto_tool.rs
+++ b/azalea/src/auto_tool.rs
@@ -1,6 +1,6 @@
 use azalea_block::{BlockState, fluid_state::FluidKind};
 use azalea_core::position::BlockPos;
-use azalea_entity::{ActiveEffects, Attributes, FluidOnEyes, Physics, inventory::Inventory};
+use azalea_entity::{ActiveEffects, Attributes, FluidOnEyes, Physics, SupportingBlockCtx, inventory::Inventory};
 use azalea_inventory::{ItemStack, Menu, components};
 use azalea_registry::builtin::{BlockKind, EntityKind};
 
@@ -55,7 +55,7 @@ impl Client {
 /// care about those things.
 pub fn best_tool_in_hotbar_for_block(block: BlockState, menu: &Menu) -> BestToolResult {
     let mut physics = Physics::default();
-    physics.set_on_ground(true, None);
+    physics.set_on_ground(true, SupportingBlockCtx::new());
 
     let inactive_effects = ActiveEffects::default();
     accurate_best_tool_in_hotbar_for_block(

--- a/azalea/src/auto_tool.rs
+++ b/azalea/src/auto_tool.rs
@@ -55,7 +55,7 @@ impl Client {
 /// care about those things.
 pub fn best_tool_in_hotbar_for_block(block: BlockState, menu: &Menu) -> BestToolResult {
     let mut physics = Physics::default();
-    physics.set_on_ground(true, SupportingBlockCtx::new());
+    physics.set_on_ground(true, SupportingBlockCtx::default());
 
     let inactive_effects = ActiveEffects::default();
     accurate_best_tool_in_hotbar_for_block(

--- a/azalea/src/auto_tool.rs
+++ b/azalea/src/auto_tool.rs
@@ -55,7 +55,7 @@ impl Client {
 /// care about those things.
 pub fn best_tool_in_hotbar_for_block(block: BlockState, menu: &Menu) -> BestToolResult {
     let mut physics = Physics::default();
-    physics.set_on_ground(true);
+    physics.set_on_ground(true, None);
 
     let inactive_effects = ActiveEffects::default();
     accurate_best_tool_in_hotbar_for_block(

--- a/azalea/src/pathfinder/execute/mod.rs
+++ b/azalea/src/pathfinder/execute/mod.rs
@@ -167,10 +167,13 @@ pub fn check_node_reached(
                     let x_difference_from_center = position.x - (movement.target.x as f64 + 0.5);
                     let z_difference_from_center = position.z - (movement.target.z as f64 + 0.5);
 
-                    let block_pos_below = get_block_pos_below_that_affects_movement(*position);
-
                     let block_below = {
                         let world = world.read();
+                        let block_pos_below = get_block_pos_below_that_affects_movement(
+                            &world.chunks,
+                            *position,
+                            physics,
+                        );
                         world
                             .chunks
                             .get_block_state(block_pos_below)


### PR DESCRIPTION
For issue https://github.com/azalea-rs/azalea/issues/350
~~Not tested, DO NOT MERGE (yet)~~

This PR introduces `main_supporting_blockpos` tracking to match vanilla, including
- updating `main_supporting_blockpos` when doing `set_on_ground` (changes the signature of `set_on_ground`, because vanilla updates those two)
  - call site within `move_colliding`, it additionally updates the bounding box after position is updated(need review for maintenance, and that update was missing all the time before this).
  - call site for packet handling, it now uses the updated bounding box. However this leaves the later `update_bounding_box` system redundant.
- uses `main_supporting_blockpos` for the `on_pos` and etc.. so that they can use the correct blockpos for determining support

Tested with a example bot, knocked down a platform, with different starting position to test edge case of landing tick moves the bot out side of the ice platform (no contact), see later posts with videos to know what tests are done.