### PR TITLE
Fix Rust 1.100.0 warnings, force older trait solver

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,8 @@
 [build]
-rustflags = ["--cfg", "docsrs_dep", "-Znext-solver=coherence"]
+rustflags = [
+  "--cfg", "docsrs_dep",
+  "-Znext-solver=coherence" # This is temporary until the new trait solver supports `min_const_generic`s
+]
 rustdocflags = [
     "--html-after-content",
     "docs-rs/trait-tags.html",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = ["--cfg", "docsrs_dep"]
+rustflags = ["--cfg", "docsrs_dep", "-Znext-solver=coherence"]
 rustdocflags = [
     "--html-after-content",
     "docs-rs/trait-tags.html",

--- a/azalea-buf/azalea-buf-macros/src/lib.rs
+++ b/azalea-buf/azalea-buf-macros/src/lib.rs
@@ -19,6 +19,7 @@ pub fn derive_azbuf(input: TokenStream) -> TokenStream {
     let writable = write::create_fn_azalea_write(&data);
     let readable = read::create_fn_azalea_read(&data);
     quote! {
+        #[automatically_derived]
         impl #impl_generics azalea_buf::AzBuf for #ident #ty_generics #where_clause {
             #writable
             #readable

--- a/azalea-buf/azalea-buf-macros/src/read.rs
+++ b/azalea-buf/azalea-buf-macros/src/read.rs
@@ -11,7 +11,7 @@ pub fn create_fn_azalea_read(data: &Data) -> proc_macro2::TokenStream {
                     fn azalea_read(buf: &mut std::io::Cursor<&[u8]>) -> std::result::Result<Self, azalea_buf::BufReadError> {
                         #(#read_fields)*
                         Ok(Self {
-                            #(#read_field_names: #read_field_names),*
+                            #(#read_field_names),*
                         })
                     }
                 }
@@ -70,7 +70,7 @@ pub fn create_fn_azalea_read(data: &Data) -> proc_macro2::TokenStream {
                         quote! {
                             #(#read_fields)*
                             Ok(Self::#variant_name {
-                                #(#read_field_names: #read_field_names),*
+                                #(#read_field_names),*
                             })
                         }
                     }

--- a/azalea-buf/src/impls/mod.rs
+++ b/azalea-buf/src/impls/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::redundant_field_names, reason = "Triggered by `Error` derive")]
+
 mod extra;
 mod primitives;
 

--- a/azalea-client/src/lib.rs
+++ b/azalea-client/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![feature(error_generic_member_access)]
+#![allow(clippy::type_complexity, reason = "Bevy Query types")]
 
 pub mod account;
 mod client;

--- a/azalea-client/src/plugins/connection.rs
+++ b/azalea-client/src/plugins/connection.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::redundant_field_names, reason = "Triggered by `Error` derive")]
+
 use std::{
     fmt::Debug,
     io::Cursor,

--- a/azalea-core/src/bitset.rs
+++ b/azalea-core/src/bitset.rs
@@ -222,6 +222,7 @@ where
         }
         Ok(FixedBitSet { data })
     }
+    #[allow(clippy::needless_range_loop, reason = "Indexing into bitset")]
     fn azalea_write(&self, buf: &mut impl Write) -> io::Result<()> {
         for i in 0..bits_to_bytes(N) {
             self.data[i].azalea_write(buf)?;

--- a/azalea-core/src/codec_utils.rs
+++ b/azalea-core/src/codec_utils.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 /// Intended to be used for skipping serialization if the value is the default.
 ///
-/// ```no_run
+/// ```ignore
 /// #[serde(skip_serializing_if = "is_default")]
 /// ```
 pub fn is_default<T: Default + PartialEq>(t: &T) -> bool {
@@ -16,7 +16,7 @@ pub fn is_default<T: Default + PartialEq>(t: &T) -> bool {
 
 /// Intended to be used for skipping serialization if the value is `true`.
 ///
-/// ```no_run
+/// ```ignore
 /// #[serde(skip_serializing_if = "is_true")]
 /// ```
 pub fn is_true(t: &bool) -> bool {
@@ -25,7 +25,7 @@ pub fn is_true(t: &bool) -> bool {
 
 /// If the array has a single item, don't serialize as an array
 ///
-/// ```no_run
+/// ```ignore
 /// #[serde(serialize_with = "flatten_array")]
 /// ```
 pub fn flatten_array<S: Serializer, T: Serialize>(x: &Vec<T>, s: S) -> Result<S::Ok, S::Error> {

--- a/azalea-entity/src/plugin/mod.rs
+++ b/azalea-entity/src/plugin/mod.rs
@@ -165,6 +165,7 @@ pub fn update_on_climbable(
     }
 }
 
+#[expect(clippy::needless_bool, reason = "Kept for future improvements")]
 fn is_trapdoor_usable_as_ladder(
     block_state: BlockState,
     block_pos: BlockPos,

--- a/azalea-protocol/src/read.rs
+++ b/azalea-protocol/src/read.rs
@@ -1,4 +1,5 @@
 //! Read packets from a stream.
+#![allow(clippy::redundant_field_names, reason = "Triggered by `Error` derive")]
 
 use std::{
     backtrace::Backtrace,

--- a/azalea/src/pathfinder/goals.rs
+++ b/azalea/src/pathfinder/goals.rs
@@ -55,16 +55,7 @@ fn xz_heuristic(dx: f32, dz: f32) -> f32 {
     let x = dx.abs();
     let z = dz.abs();
 
-    let diagonal;
-    let straight;
-
-    if x < z {
-        straight = z - x;
-        diagonal = x;
-    } else {
-        straight = x - z;
-        diagonal = z;
-    }
+    let (diagonal, straight) = if x < z { (z - x, x) } else { (x - z, z) };
 
     (diagonal * SQRT_2 + straight) * COST_HEURISTIC
 }

--- a/azalea/src/pathfinder/goals.rs
+++ b/azalea/src/pathfinder/goals.rs
@@ -55,7 +55,8 @@ fn xz_heuristic(dx: f32, dz: f32) -> f32 {
     let x = dx.abs();
     let z = dz.abs();
 
-    let (diagonal, straight) = if x < z { (z - x, x) } else { (x - z, z) };
+    // Swap `x` and `z` depending on the size.
+    let (diagonal, straight) = if x < z { (x, z - x) } else { (z, x - z) };
 
     (diagonal * SQRT_2 + straight) * COST_HEURISTIC
 }

--- a/azalea/src/pathfinder/world.rs
+++ b/azalea/src/pathfinder/world.rs
@@ -1,4 +1,3 @@
-use core::f32;
 use std::{
     array,
     cell::{RefCell, UnsafeCell},
@@ -661,6 +660,7 @@ pub fn is_block_state_passable(block_state: BlockState) -> bool {
 /// Whether this block has a solid hitbox at the top (i.e. we can stand on it
 /// and do parkour from it).
 #[inline]
+#[expect(clippy::needless_bool, reason = "Kept for future improvements")]
 pub fn is_block_state_solid(block_state: BlockState) -> bool {
     if block_state.is_air() {
         // fast path


### PR DESCRIPTION
Hopefully `generic_const_exprs` is added back soon...

Until then the solver must be set with `-Znext-solver=coherence`.
Doing it in-repo only effects azalea dev, other projects must set it themselves.

Edit: Seems like `min_generic_const_args`/`generic_const_args` is a "successor"?
Or at least a replacement. Either way, the Rust doc examples for it don't seem to work yet.